### PR TITLE
Use recent version without comment in query

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,10 @@ properties([
 ])
 
 node('docker') {
-    timestamps {
-        docker.image('cloudbees/java-build-tools').inside() {
-            stage('Run the tests') {
-                git url: 'https://github.com/jenkins-infra/acceptance-tests.git', branch: "update-site"
-                sh 'bash ./test.sh'
-            }
+    docker.image('cloudbees/java-build-tools').inside() {
+        stage('Run the tests') {
+            git url: 'https://github.com/jenkins-infra/acceptance-tests.git', branch: "update-site"
+            sh 'bash ./test.sh'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,21 +5,23 @@ properties([
     pipelineTriggers([cron('@hourly')]),
 ])
 
-node('docker') {
-    docker.image('cloudbees/java-build-tools').inside() {
-        stage('Run the tests') {
-            checkout(
-                [ $class: 'GitSCM',
-                  branches: scm.branches, // Assumes the multibranch pipeline checkout branch definition is good enough
-                  extensions: [
-                        [ $class: 'CloneOption', honorRefspec: true, noTags: true ],
-                        [ $class: 'LocalBranch', localBranch: env.BRANCH_NAME ],
-                  ],
-                  gitTool: scm.gitTool,
-                  userRemoteConfigs: scm.userRemoteConfigs // Assumes the multibranch pipeline checkout remoteconfig is good enough
-                ]
-            )
-            sh 'bash ./test.sh'
+timeout(time: 45, unit: 'MINUTES') {
+    node('docker') {
+        docker.image('cloudbees/java-build-tools').inside() {
+            stage('Run the tests') {
+                checkout(
+                    [ $class: 'GitSCM',
+                      branches: scm.branches, // Assumes the multibranch pipeline checkout branch definition is good enough
+                      extensions: [
+                            [ $class: 'CloneOption', honorRefspec: true, noTags: true ],
+                            [ $class: 'LocalBranch', localBranch: env.BRANCH_NAME ],
+                      ],
+                      gitTool: scm.gitTool,
+                      userRemoteConfigs: scm.userRemoteConfigs // Assumes the multibranch pipeline checkout remoteconfig is good enough
+                    ]
+                )
+                sh 'bash ./test.sh'
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,17 @@ properties([
 node('docker') {
     docker.image('cloudbees/java-build-tools').inside() {
         stage('Run the tests') {
-            git url: 'https://github.com/jenkins-infra/acceptance-tests.git', branch: "update-site"
+            checkout(
+                [ $class: 'GitSCM',
+                  branches: scm.branches, // Assumes the multibranch pipeline checkout branch definition is good enough
+                  extensions: [
+                        [ $class: 'CloneOption', honorRefspec: true, noTags: true ],
+                        [ $class: 'LocalBranch', localBranch: env.BRANCH_NAME ],
+                  ],
+                  gitTool: scm.gitTool,
+                  userRemoteConfigs: scm.userRemoteConfigs // Assumes the multibranch pipeline checkout remoteconfig is good enough
+                ]
+            )
             sh 'bash ./test.sh'
         }
     }

--- a/version-redirects.test.sh
+++ b/version-redirects.test.sh
@@ -26,11 +26,11 @@ function checkRedirect() {
   fi
 }
 
-checkRedirect "2.46" "2.46"
-checkRedirect "2.46.1" "stable-2.46"
-checkRedirect "2.46.3" "stable-2.46"
-checkRedirect "2.46.3.1" "stable-2.46"
-checkRedirect "2.46.3-SNAPSHOT (someone built this now)" "stable-2.46"
-checkRedirect "2.46.3-1234567" "stable-2.46"
+checkRedirect "2.204"                   "2.204"
+checkRedirect "2.204.1"          "stable-2.204"
+checkRedirect "2.204.3"          "stable-2.204"
+checkRedirect "2.204.3.1"        "stable-2.204"
+checkRedirect "2.204.3-SNAPSHOT" "stable-2.204"
+checkRedirect "2.204.3-1234567"  "stable-2.204"
 
 exit $result


### PR DESCRIPTION
## Use recent version without comment, test 2.204 instead of 2.46

The 'someone built this now' comment is no longer ignored in choosing the redirection answer.  No redirection is returned when that extra text is included in the query.

Update from 2.46 to the most recent Jenkins long term support release, 2.204.x, so that the returned version matches with the passed in argument.  That will allow the test to run successfully for roughly 9 months before the next change.

Removed the timestamp step for declarative pipeline since it is already declared globally on ci.jenkins.io.

Adapt the checkout command to use the current branch name rather than a hard-coded branch name.  Otherwise, can't evaluate pull requests.