### PR TITLE
Adapt update site acceptance tests to latest UC

### DIFF
--- a/version-redirects.test.sh
+++ b/version-redirects.test.sh
@@ -26,11 +26,33 @@ function checkRedirect() {
   fi
 }
 
-checkRedirect "2.204"                   "2.204"
-checkRedirect "2.204.1"          "stable-2.204"
-checkRedirect "2.204.3"          "stable-2.204"
-checkRedirect "2.204.3.1"        "stable-2.204"
-checkRedirect "2.204.3-SNAPSHOT" "stable-2.204"
-checkRedirect "2.204.3-1234567"  "stable-2.204"
+checkRedirect "2.204"            "dynamic-2.200"          # Weekly falls back
+
+checkRedirect "2.204.1"          "dynamic-stable-2.204.6" # LTS takes latest release on stable branch
+checkRedirect "2.204.3"          "dynamic-stable-2.204.6"
+checkRedirect "2.204.6"          "dynamic-stable-2.204.6"
+
+checkRedirect "2.204.3.1"        "current"                # Unrecognized version takes current
+checkRedirect "2.204.3-SNAPSHOT" "current"
+checkRedirect "2.204.3-1234567"  "current"
+
+checkRedirect "2.222"            "dynamic-2.217"          # Weekly falls back
+
+checkRedirect "2.222.1"          "dynamic-stable-2.222.4" # LTS takes latest release on stable branch
+checkRedirect "2.222.3"          "dynamic-stable-2.222.4"
+checkRedirect "2.222.4"          "dynamic-stable-2.222.4"
+
+checkRedirect "2.222.3.1"        "current"                # Unrecognized version takes current
+checkRedirect "2.222.3-SNAPSHOT" "current"
+checkRedirect "2.222.3-1234567"  "current"
+
+checkRedirect "2.235"            "dynamic-2.223"          # Weekly falls back
+
+checkRedirect "2.235.1"          "dynamic-stable-2.222.4" # Should take latest release on stable branch?
+checkRedirect "2.235.1"          "dynamic-stable-2.222.4"
+
+checkRedirect "2.235.1.1"        "current"                # Unrecognized version takes current
+checkRedirect "2.235.1-SNAPSHOT" "current"
+checkRedirect "2.235.1-1234567"  "current"
 
 exit $result

--- a/version-redirects.test.sh
+++ b/version-redirects.test.sh
@@ -26,7 +26,7 @@ function checkRedirect() {
   fi
 }
 
-checkRedirect "2.204"            "dynamic-2.200"          # Weekly falls back
+checkRedirect "2.204"            "dynamic-2.204"
 
 checkRedirect "2.204.1"          "dynamic-stable-2.204.6" # LTS takes latest release on stable branch
 checkRedirect "2.204.3"          "dynamic-stable-2.204.6"
@@ -36,7 +36,7 @@ checkRedirect "2.204.3.1"        "current"                # Unrecognized version
 checkRedirect "2.204.3-SNAPSHOT" "current"
 checkRedirect "2.204.3-1234567"  "current"
 
-checkRedirect "2.222"            "dynamic-2.217"          # Weekly falls back
+checkRedirect "2.222"            "dynamic-2.222"
 
 checkRedirect "2.222.1"          "dynamic-stable-2.222.4" # LTS takes latest release on stable branch
 checkRedirect "2.222.3"          "dynamic-stable-2.222.4"
@@ -48,8 +48,9 @@ checkRedirect "2.222.3-1234567"  "current"
 
 checkRedirect "2.235"            "dynamic-2.223"          # Weekly falls back
 
-checkRedirect "2.235.1"          "dynamic-stable-2.222.4" # Should take latest release on stable branch?
-checkRedirect "2.235.1"          "dynamic-stable-2.222.4"
+checkRedirect "2.235.1"          "dynamic-stable-2.235.2" # LTS takes latest release on stable branch
+checkRedirect "2.235.2"          "dynamic-stable-2.235.2"
+# checkRedirect "2.235.3"          "dynamic-stable-2.235.3"
 
 checkRedirect "2.235.1.1"        "current"                # Unrecognized version takes current
 checkRedirect "2.235.1-SNAPSHOT" "current"


### PR DESCRIPTION
## Adapt update site acceptance tests to latest UC

The latest update center release includes major improvements from Daniel Beck.  The improvements have changed some of the redirects.

This pull requests describes the current redirect behavior.

I'd like a review from @daniel-beck to confirm that the redirect behaviors listed in the test are the expected behaviors.  For example:

* Weekly releases fall back to some preceding weekly (assumed because they are somehow equivalent in terms of update center behavior)
* LTS releases fall back to the most recent LTS on their stable-2.xxx branch
* Most recent LTS release, 2.235.1, falls back to 2.222.4 (assumed because they are somehow equivalent in terms of update center behavior)

I know that @daniel-beck announced all the details of the update center changes and that they have all been reviewed and approved.  I didn't read them in enough detail to be confident that I've understood the general behaviors correctly.  I'm taking the "easy way out" and asking @daniel-beck to confirm that the observed test results are also the desired and expected results.

These "update site acceptance tests" are run once an hour on [ci.jenkins.io](https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/update-site/).  I was supposed to create a DataDog dashboard that would raise an alert if any of the [acceptance tests](https://ci.jenkins.io/job/Infra/job/acceptance-tests/) fail.  I have not done that yet.  My mistake shows because we've had this test failing for 9 days without me taking action on it.