### PR TITLE
Simplify update-site tested cases

### DIFF
--- a/version-redirects.test.sh
+++ b/version-redirects.test.sh
@@ -28,32 +28,20 @@ function checkRedirect() {
 
 checkRedirect "2.204"            "dynamic-2.204"
 
-checkRedirect "2.204.1"          "dynamic-stable-2.204.6" # LTS takes latest release on stable branch
-checkRedirect "2.204.3"          "dynamic-stable-2.204.6"
 checkRedirect "2.204.6"          "dynamic-stable-2.204.6"
-
-checkRedirect "2.204.3.1"        "current"                # Unrecognized version takes current
-checkRedirect "2.204.3-SNAPSHOT" "current"
-checkRedirect "2.204.3-1234567"  "current"
 
 checkRedirect "2.222"            "dynamic-2.222"
 
-checkRedirect "2.222.1"          "dynamic-stable-2.222.4" # LTS takes latest release on stable branch
-checkRedirect "2.222.3"          "dynamic-stable-2.222.4"
 checkRedirect "2.222.4"          "dynamic-stable-2.222.4"
-
-checkRedirect "2.222.3.1"        "current"                # Unrecognized version takes current
-checkRedirect "2.222.3-SNAPSHOT" "current"
-checkRedirect "2.222.3-1234567"  "current"
 
 checkRedirect "2.235"            "dynamic-2.223"          # Weekly falls back
 
-checkRedirect "2.235.1"          "dynamic-stable-2.235.2" # LTS takes latest release on stable branch
 checkRedirect "2.235.2"          "dynamic-stable-2.235.2"
-# checkRedirect "2.235.3"          "dynamic-stable-2.235.3"
 
-checkRedirect "2.235.1.1"        "current"                # Unrecognized version takes current
-checkRedirect "2.235.1-SNAPSHOT" "current"
-checkRedirect "2.235.1-1234567"  "current"
+checkRedirect "2.235.2.1"        "current"                # Unrecognized version takes current
+checkRedirect "2.235.2-SNAPSHOT" "current"
+checkRedirect "2.235.2-1234567"  "current"
+
+checkRedirect "2.251"            "dynamic-2.251"
 
 exit $result


### PR DESCRIPTION
## Simplify update-site tested cases

This is intended to be a minimal acceptance test, not a detailed validation test of the update center rules.

We may want to drop this test completely since the update center is already very well tested by @daniel-beck .  The test runs at https://ci.jenkins.io/job/Infra/job/acceptance-tests/ .  Tests from that repository have been helpful detecting repository signing issues, but are not frequently monitored by anyone other than me.