### PR TITLE
One redhat LTS build at a time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 #!/usr/bin/env groovy
 
+// Only one build running at a time, stop prior build if new build starts
+def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber) // Thanks to jglick
+
 properties([
     [$class: 'jenkins.model.BuildDiscarderProperty',
         strategy: [$class: 'LogRotator', numToKeepStr: '5']],


### PR DESCRIPTION
## One redhat LTS build at a time

When ci.jenkins.io is heavily loaded, the acceptance tests may be delayed.
Rather than add more jobs to run, this milestone limits to one build
running at a time.