### PR TITLE
Fix update-site tests

### DIFF
--- a/version-redirects.test.sh
+++ b/version-redirects.test.sh
@@ -28,8 +28,6 @@ function checkRedirect() {
 
 checkRedirect "2.204"            "dynamic-2.204"
 
-checkRedirect "2.204.1"          "dynamic-stable-2.204.6" # LTS takes latest release on stable branch
-checkRedirect "2.204.3"          "dynamic-stable-2.204.6"
 checkRedirect "2.204.6"          "dynamic-stable-2.204.6"
 
 checkRedirect "2.204.3.1"        "current"                # Unrecognized version takes current
@@ -38,22 +36,19 @@ checkRedirect "2.204.3-1234567"  "current"
 
 checkRedirect "2.222"            "dynamic-2.222"
 
-checkRedirect "2.222.1"          "dynamic-stable-2.222.4" # LTS takes latest release on stable branch
-checkRedirect "2.222.3"          "dynamic-stable-2.222.4"
 checkRedirect "2.222.4"          "dynamic-stable-2.222.4"
 
 checkRedirect "2.222.3.1"        "current"                # Unrecognized version takes current
 checkRedirect "2.222.3-SNAPSHOT" "current"
 checkRedirect "2.222.3-1234567"  "current"
 
-checkRedirect "2.235"            "dynamic-2.223"          # Weekly falls back
-
-checkRedirect "2.235.1"          "dynamic-stable-2.235.2" # LTS takes latest release on stable branch
 checkRedirect "2.235.2"          "dynamic-stable-2.235.2"
-# checkRedirect "2.235.3"          "dynamic-stable-2.235.3"
+checkRedirect "2.235.3"          "dynamic-stable-2.235.3"
 
 checkRedirect "2.235.1.1"        "current"                # Unrecognized version takes current
 checkRedirect "2.235.1-SNAPSHOT" "current"
 checkRedirect "2.235.1-1234567"  "current"
+
+checkRedirect "2.263.1"          "dynamic-stable-2.263.1"
 
 exit $result


### PR DESCRIPTION
Fix the acceptance tests on the [update-site branch](https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/update-site/).

Checking the status of the site is more valuable than specific detailed checks.  The specific details are already checked in automated tests of update-center2 repository.
