### PR TITLE
Adapt update site checks to SNAPSHOT improvements

### DIFF
--- a/version-redirects.test.sh
+++ b/version-redirects.test.sh
@@ -31,23 +31,23 @@ checkRedirect "2.204"            "dynamic-2.204"
 checkRedirect "2.204.6"          "dynamic-stable-2.204.6"
 
 checkRedirect "2.204.3.1"        "current"                # Unrecognized version takes current
-checkRedirect "2.204.3-SNAPSHOT" "current"
-checkRedirect "2.204.3-1234567"  "current"
+checkRedirect "2.204.3-SNAPSHOT" "dynamic-stable-2.204.2"
+checkRedirect "2.204.3-1234567"  "dynamic-stable-2.204.2"
 
 checkRedirect "2.222"            "dynamic-2.222"
 
 checkRedirect "2.222.4"          "dynamic-stable-2.222.4"
 
 checkRedirect "2.222.3.1"        "current"                # Unrecognized version takes current
-checkRedirect "2.222.3-SNAPSHOT" "current"
-checkRedirect "2.222.3-1234567"  "current"
+checkRedirect "2.222.3-SNAPSHOT" "dynamic-stable-2.222.3"
+checkRedirect "2.222.3-1234567"  "dynamic-stable-2.222.3"
 
 checkRedirect "2.235.2"          "dynamic-stable-2.235.2"
 checkRedirect "2.235.3"          "dynamic-stable-2.235.3"
 
 checkRedirect "2.235.1.1"        "current"                # Unrecognized version takes current
-checkRedirect "2.235.1-SNAPSHOT" "current"
-checkRedirect "2.235.1-1234567"  "current"
+checkRedirect "2.235.1-SNAPSHOT" "dynamic-stable-2.235.1"
+checkRedirect "2.235.1-1234567"  "dynamic-stable-2.235.1"
 
 checkRedirect "2.263.1"          "dynamic-stable-2.263.1"
 


### PR DESCRIPTION
Update center has been extended to return a previous revision when a SNAPSHOT is requested. That allows automated tests in Jenkins core to run and is not an unreasonable choice for the user.