### PR TITLE
Install EPEL on CentOS for install test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node('docker') {
     timestamps {
         docker.image('centos').inside('-u 0:0') {
             stage('Prepare Container') {
-                sh 'yum install -y wget'
+                sh 'yum install -y wget epel-release'
             }
 
             stage('Add the rpm key') {


### PR DESCRIPTION
Jenkins 2.306 rpm requires the daemonize package that is available from
epel-release.
