### PR TITLE
Install EPEL on CentOS for install test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node('docker') {
     timestamps {
         docker.image('centos').inside('-u 0:0') {
             stage('Prepare Container') {
-                sh 'yum install -y wget'
+                sh 'yum install -y wget epel-release'
             }
 
             stage('Add the rpm key') {


### PR DESCRIPTION
Weekly 2.306 requires epel for the daemonize program
