### PR TITLE
Exclude ppc64le from LTS install test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ properties([
 ])
 
 // Define processors
-def Processors = [ "arm64docker", "docker", "ppc64ledocker", "s390xdocker" ]
+def Processors = [ "arm64docker", "docker", "s390xdocker" ] // "ppc64ledocker" excluded because test machine cannot download the jenkins package
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {


### PR DESCRIPTION
## Exclude ppc64le from LTS install acceptance test

The docker container inside the ppc64le agent fails to download the installer.  The s390x, aarch64, and amd64 docker containers do not have that issue on their agents.
