### PR TITLE
Use keyring instead of apt-key for Debian LTS install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,11 +30,11 @@ def generateParallelSteps(labels) {
                         }
 
                         stage('Add the apt key') {
-                            sh 'wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | apt-key add -'
+                            sh 'curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null'
                         }
 
                         stage('Install Jenkins from apt') {
-                            sh 'echo "deb https://pkg.jenkins.io/debian-stable binary/" >> /etc/apt/sources.list'
+                            sh 'sudo sh -c \'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list\''
                             sh 'apt-get update && apt-get install -qy jenkins'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def generateParallelSteps(labels) {
                 timestamps {
                     docker.image('debian').inside('-u 0:0') {
                         stage('Prepare Container') {
-                            sh 'apt-get update -q -y && apt-get install -q -y --allow-change-held-packages wget curl apt-transport-https gnupg2'
+                            sh 'apt-get update -q -y && apt-get install -q -y --allow-change-held-packages wget curl apt-transport-https'
                         }
 
                         stage('Add the apt key') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def generateParallelSteps(labels) {
                 timestamps {
                     docker.image('debian').inside('-u 0:0') {
                         stage('Prepare Container') {
-                            sh 'apt-get update -q -y && apt-get install -q -y --allow-change-held-packages wget curl apt-transport-https'
+                            sh 'apt-get update -q -y && apt-get install -q -y --allow-change-held-packages curl apt-transport-https'
                         }
 
                         stage('Add the apt key') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ def generateParallelSteps(labels) {
                         }
 
                         stage('Install Jenkins from apt') {
-                            sh 'echo \'deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary\' | tee /etc/apt/sources.list.d/jenkins.list > /dev/null'
+                            sh 'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary/ | tee /etc/apt/sources.list.d/jenkins.list > /dev/null'
                             sh 'apt-get update && apt-get install -qy jenkins'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,15 +26,15 @@ def generateParallelSteps(labels) {
                 timestamps {
                     docker.image('debian').inside('-u 0:0') {
                         stage('Prepare Container') {
-                            sh 'apt-get update -q -y && apt-get install -q -y --allow-change-held-packages wget apt-transport-https gnupg2'
+                            sh 'apt-get update -q -y && apt-get install -q -y --allow-change-held-packages wget curl apt-transport-https gnupg2'
                         }
 
                         stage('Add the apt key') {
-                            sh 'curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null'
+                            sh 'curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null'
                         }
 
                         stage('Install Jenkins from apt') {
-                            sh 'sudo sh -c \'echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list\''
+                            sh 'echo \'deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary\' | tee /etc/apt/sources.list.d/jenkins.list > /dev/null'
                             sh 'apt-get update && apt-get install -qy jenkins'
                         }
                     }


### PR DESCRIPTION
# Use keyring instead of apt-key for Debian LTS install

See https://github.com/jenkins-infra/jenkins.io/pull/4675 for the explanation of the replacement of apt-key with better solutions.
