### PR TITLE
fix(Jenkinsfile): change label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ properties([
 def sequentialStages = [:]
 // Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
 sequentialStages['Container-Tools'] = [ 'maven', 'maven-11', 'maven-17', 'maven-21', 'maven-8-windows', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows']
-sequentialStages['VM-Tools'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17', 'ubuntu-22-amd64-highmem-nonspot-maven17']
+sequentialStages['VM-Tools'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17', 'ubuntu-22-amd64-highmem-maven17-nonspot']
 sequentialStages['Processor'] = [ 's390x', 'amd64' ] // 'arm64', not tested, unavailable
 sequentialStages['Docker'] = [ 's390xdocker', 'docker', 'docker-windows'] //'arm64docker', not tested, unavailable
 


### PR DESCRIPTION
since https://github.com/jenkins-infra/jenkins-infra/pull/3959 the label changed from `ubuntu-22-amd64-highmem-nonspot-maven17` to `ubuntu-22-amd64-highmem-maven17-nonspot`