### PR TITLE
feat(check-agents-availability) update the labels to be tested

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-
 sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
 sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
 sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker']
-sequentialStages['Spot and OnDemand'] = [ 'maven-21 && spot', 'maven-21 && nonspot', 'maven-17-windows && spot', 'maven-17-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
+sequentialStages['Spot and OnDemand'] = [ 'maven-17-windows && spot', 'maven-17-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,9 @@ def generateParallelSteps(labels) {
             node(label) {
                 if (isUnix()) {
                     checkout scm
-                    sh 'bash ./checks.sh '+label
+                    withEnv(["NODE_LABEL=${label}"]) {
+                        sh 'bash ./checks.sh "${NODE_LABEL}"'
+                    }
                 } else {
                     bat 'set | findstr PROCESSOR'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,11 @@ properties([
 // Define the sequential stages and the parallel steps inside each stage
 def sequentialStages = [:]
 // Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
-sequentialStages['Container-Tools'] = [ 'maven', 'maven-11', 'maven-17', 'maven-21', 'maven-8-windows', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows']
-sequentialStages['VM-Tools'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17', 'ubuntu-22-amd64-highmem-maven17-nonspot']
-sequentialStages['Processor'] = [ 's390x', 'amd64' ] // 'arm64', not tested, unavailable
-sequentialStages['Docker'] = [ 's390xdocker', 'docker', 'docker-windows'] //'arm64docker', not tested, unavailable
+sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-21', 'maven-8-windows', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows']
+sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
+sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
+sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker']
+sequentialStages['Spot and OnDemand'] = [ 'maven-21 && spot', 'maven-21 && nonspot', 'maven-17-windows && spot', 'maven-17-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {

--- a/checks.sh
+++ b/checks.sh
@@ -73,14 +73,12 @@ mvn -v 2>/dev/null >/dev/null || {
 # Java 8 needs to include '1.8' in the output
 # Java 11 needs to include '11.' in the output
 # Java 17 needs to include '17.' in the output
-# kubernetes label does not commit to a specific Java version, don't check it
-# amd64 label does not commit to a specific Java version, don't check it
-if [ $# -ge 1 ] && [ -n "$1" ] && [ "$1" != "amd64" ] && [ "$1" != "kubernetes" ]; then
+if [ $# -ge 1 ] && [ -n "$1" ]; then
 	echo "label of the node: $1"
 
 	jdk="${DefaultJDKVersion}"
 	case "$1" in
-	*maven | *maven-8 | *jdk-8 | *maven8)
+	*maven-8 | *jdk-8 | *maven8)
 		jdk="jdk-8";;
 	*maven-11 | *jdk-11 | *maven11)
 		jdk="jdk-11";;


### PR DESCRIPTION
This change introduces an update in the collection of labels to be tested:

- A bit of stages renaming and script cleanup
- Remove test of the `maven` label as per https://github.com/jenkins-infra/pipeline-library/pull/926
  - We also stopped testing `maven-windows` a few weeks ago and it's now officially removed
- Adding tests for `arm64` which required setting up the prefix `linux-` or suffix `docker`
  - Note: we might want to update s390x labels with the same prefix `linux-`
- Add the support for the spot/nonspot labels used since a few weeks:
  - In the pipeline library `buildPlugin()`: https://github.com/jenkins-infra/pipeline-library/blob/050aae058e71a42a75f8d7c83c63f9ea9acfb65e/vars/buildPlugin.groovy#L52-L54
  - In the Jenkins ATH builds: https://github.com/jenkinsci/acceptance-test-harness/blob/864deadd9d08dac62e75a038aaba2067c2414839/Jenkinsfile#L117
  - In the docker-agent and docker-ssh-agent builds: https://github.com/jenkinsci/docker-agent/blob/ce8fc915c8b6a3787f487377e62fa22262c92017/Jenkinsfile#L37 and https://github.com/jenkinsci/docker-ssh-agent/blob/6465dd8afba65cd0ffe0ba9d493f2e120f0e9aa8/Jenkinsfile#L37