### PR TITLE
fix(checks): bump the default jdk to jdk-21

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -3,7 +3,7 @@ set -eux -o pipefail
 
 DefaultLocale="en_US.utf8"
 DefaultMavenVersion="3.9.9"
-DefaultJDKVersion="jdk-17"
+DefaultJDKVersion="jdk-21"
 DefaultUser="jenkins"
 
 # Allow Mark Waite to run the same script on his home network


### PR DESCRIPTION
since https://github.com/jenkins-infra/helpdesk/issues/4120 we use jdk-21 as default java. (Agents with the jdk in their name, use this one as default)