### PR TITLE
feat: add a docker controller image build check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,73 @@
+#!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '15')),
+    // Do not resume build after controller restart
+    disableResume(),
+    durabilityHint('PERFORMANCE_OPTIMIZED'),
+    pipelineTriggers([cron('@daily')]),
+])
+
+// TODO: specify architecture and add corresponding processors if more than amd64 agents are used by docker image jobs on this controller
+// Define processors
+def ProcessorsLabelsAndDockerBakeTargets = [
+    'ubuntu-amd64-maven-21': ['alpine_jdk21', 'debian_jdk25'],
+    'ubuntu-arm64-maven-21': ['arm64'],
+    'win-2022-amd64-maven-21': ['windowsservercore-ltsc2022']
+]
+
+// Generate a parallel step for each label in labels
+def generateParallelSteps(processors) {
+    def parallelNodes = [:]
+    processors.each { unboundLabel, unboundTargetList ->
+        // Bind before the closure
+        def label = unboundLabel
+        def targetList = unboundTargetList
+        targetList.each { unboundTarget ->
+            def target = unboundTarget
+            def combination = "$target built on $label"
+            parallelNodes[combination] = {
+                node(label) {
+                    timestamps {
+                        withEnv([
+                            "REVISION=2.546",
+                            "DOCKER_BAKE_TARGET_TO_BUILD=$target"
+                        ]) {
+                            stage("Retrieve jenkinsci/docker at a specific revision") {
+                                if (isUnix()) {
+                                    sh 'git clone https://github.com/jenkinsci/docker && cd docker && git checkout "${REVISION}"'
+                                } else {
+                                    pwsh 'git clone https://github.com/jenkinsci/docker && cd docker && git checkout "${REVISION}"'
+                                }
+                            }
+                            stage("Build docker bake target") {
+                                dir('docker') {
+                                    if (isUnix()) {
+                                        sh '''
+                                            docker info
+                                            # Fallback to buildarch-% in case the target is an "architecture" one
+                                            make "build-${DOCKER_BAKE_TARGET_TO_BUILD}" || make "buildarch-${DOCKER_BAKE_TARGET_TO_BUILD}"
+                                        '''
+                                    } else {
+                                        // TODO: review when jenkinsci/docker/make.ps1 allows to specify the target to build
+                                        pwsh '''
+                                            docker info
+                                            ./make.ps1 build
+                                        '''
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }  
+    return parallelNodes
+}
+
+timeout(unit: 'MINUTES', time: 60) {
+    stage('Processor') {
+        parallel generateParallelSteps(ProcessorsLabelsAndDockerBakeTargets)
+    }
+}

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,5 @@
+# Check docker image build
+
+This test ensures the docker controller image can be build (not pushed) on Linux and Windows.
+
+It allows the choice of any combination of agent label(s) and target(s) per agent to build.


### PR DESCRIPTION
This change allows to check the build of https://github.com/jenkinsci/docker at a specific revision, on any combination of agent label and target(s) per agent.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4791#issuecomment-3737354371

---

> [!NOTE]
> 
>
> <details><summary>To be able to open this PR, I've used the following commands:</summary>
> 
> 
> ```bash
> # Clone repo in a distinct folder than my existing fork clone
> $ git clone https://github.com/jenkins-infra/acceptance-tests ath-infra
> $ cd ath-infra
> 
> # Create orphan branch
> $ git switch --orphan check-docker-controller-build
> Switched to a new branch 'check-docker-controller-build'
> 
> # Create empty common base commit
> $ git commit --allow-empty -m "Empty commit to initialise the branch"
> [check-docker-controller-build (root-commit) 2ec8392] Empty commit to initialise the branch
> 
> # Push that new empty branch to this repository
> $ git push -u origin check-docker-controller-build
> Enumerating objects: 2, done.
> Counting objects: 100% (2/2), done.
> Writing objects: 100% (2/2), 852 bytes | 852.00 KiB/s, done.
> Total 2 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
> remote: 
> remote: Create a pull request for 'check-docker-controller-build' on GitHub by visiting:
> remote:      https://github.com/jenkins-infra/acceptance-tests/pull/new/check-docker-controller-build
> remote: 
> To https://github.com/jenkins-infra/acceptance-tests
>  * [new branch]      check-docker-controller-build -> check-docker-controller-build
> branch 'check-docker-controller-build' set up to track 'origin/check-docker-controller-build'.
> 
> # Rebase this branch into my fork branch
> $ cd ../acceptance-tests
> $ git fetch --all --prune
> $ git rebase upstream/check-docker-controller-build
> Successfully rebased and updated refs/heads/check-docker-controller-build.
> 
> # Check and push my updated branch with the common init commit to my fork
> $ git log --one-line
> 4ade55d (HEAD -> check-docker-controller-build, origin/check-docker-controller-build) feat: add a docker build check on Linux and Windows
> 2ec8392 (upstream/check-docker-controller-build) Empty commit to initialise the branch
> 
> $ git remote -v
> git remote -v
> origin  https://github.com/lemeurherve/acceptance-tests.git (fetch)
> origin  https://github.com/lemeurherve/acceptance-tests.git (push)
> upstream        https://github.com/jenkins-infra/acceptance-tests.git (fetch)
> upstream        https://github.com/jenkins-infra/acceptance-tests.git (push)
> 
> $ git push -u origin check-docker-controller-build
> Enumerating objects: 5, done.
> Counting objects: 100% (5/5), done.
> Delta compression using up to 14 threads
> Compressing objects: 100% (4/4), done.
> Writing objects: 100% (4/4), 2.19 KiB | 2.19 MiB/s, done.
> Total 4 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
> To https://github.com/lemeurherve/acceptance-tests.git
>  + 1e60175...4ade55d check-docker-controller-build -> check-docker-controller-build
> 
> ```
> 
> </details>