### PR TITLE
feat(trusted.ci|cert.ci): import infra health agent pipelines as code, add `docker info` and align them

### DIFF
--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -41,8 +41,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
 
       /** TODO: uncomment when adding JDK25
       String jdk25 = tool name: "jdk-25", type: 'jdk'
@@ -109,8 +109,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -120,8 +120,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -131,8 +131,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -142,8 +142,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 }

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -3,6 +3,8 @@ parallel "linux": {
     node('linux') {
       sh 'java -version'
       sh 'mvn -v'
+      sh 'docker info'
+      sh 'cat /proc/cpuinfo'
       
       /** TODO: uncomment when adding JDK25
       String jdk25 = tool name: "jdk-25", type: 'jdk'
@@ -38,7 +40,10 @@ parallel "linux": {
     node('windows') {
       bat 'java -version'
       bat 'mvn -v'
-      
+      bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+
       /** TODO: uncomment when adding JDK25
       String jdk25 = tool name: "jdk-25", type: 'jdk'
       withEnv(["PATH+JDK=${jdk25}/bin", "JAVA_HOME=${jdk25}"]) {
@@ -73,6 +78,8 @@ parallel "linux": {
     node('ubuntu-22-amd64-maven-11') {
       sh 'java -version'
       sh 'mvn -v'
+      sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },
@@ -81,6 +88,8 @@ parallel "linux": {
     node('ubuntu-22-amd64-maven-17') {
       sh 'java -version'
       sh 'mvn -v'
+      sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },
@@ -89,6 +98,8 @@ parallel "linux": {
     node('ubuntu-22-amd64-maven-21') {
       sh 'java -version'
       sh 'mvn -v'
+      sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },
@@ -97,6 +108,9 @@ parallel "linux": {
     node('win-2019-amd64-maven-11') {
       bat 'java -version'
       bat 'mvn -v'
+      bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -105,6 +119,9 @@ parallel "linux": {
     node('win-2019-amd64-maven-17') {
       bat 'java -version'
       bat 'mvn -v'
+      bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -113,6 +130,9 @@ parallel "linux": {
     node('win-2019-amd64-maven-21') {
       bat 'java -version'
       bat 'mvn -v'
+      bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -121,6 +141,9 @@ parallel "linux": {
     node('win-2025-amd64-maven-25') {
       bat 'java -version'
       bat 'mvn -v'
+      bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 }

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -1,0 +1,126 @@
+parallel "linux": {
+  stage('Test default "linux" agent label with tools') {
+    node('linux') {
+      sh 'java -version'
+      sh 'mvn -v'
+      
+      /** TODO: uncomment when adding JDK25
+      String jdk25 = tool name: "jdk-25", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk25}/bin", "JAVA_HOME=${jdk25}"]) {
+        sh 'mvn -v'
+      }
+      **/
+      
+      String jdk21 = tool name: "jdk21", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk21}/bin", "JAVA_HOME=${jdk21}"]) {
+        sh 'mvn -v'
+      }
+
+      String jdk17 = tool name: "jdk17", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk17}/bin", "JAVA_HOME=${jdk17}"]) {
+        sh 'mvn -v'
+      }
+
+      String jdk11 = tool name: "jdk11", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk11}/bin", "JAVA_HOME=${jdk11}"]) {
+        sh 'mvn -v'
+      }
+    
+      String jdk8 = tool name: "jdk8", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk8}/bin", "JAVA_HOME=${jdk8}"]) {
+          sh 'mvn -v'
+      }
+    }
+  }
+},
+"windows": {
+  stage('Test default "windows" agent label with tools') {
+    node('windows') {
+      bat 'java -version'
+      bat 'mvn -v'
+      
+      /** TODO: uncomment when adding JDK25
+      String jdk25 = tool name: "jdk-25", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk25}/bin", "JAVA_HOME=${jdk25}"]) {
+        bat 'mvn -v'
+      }
+      **/
+      
+      String jdk21 = tool name: "jdk21", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk21}/bin", "JAVA_HOME=${jdk21}"]) {
+        bat 'mvn -v'
+      }
+
+      String jdk17 = tool name: "jdk17", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk17}/bin", "JAVA_HOME=${jdk17}"]) {
+        bat 'mvn -v'
+      }
+
+      String jdk11 = tool name: "jdk11", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk11}/bin", "JAVA_HOME=${jdk11}"]) {
+        bat 'mvn -v'
+      }
+    
+      String jdk8 = tool name: "jdk8", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk8}/bin", "JAVA_HOME=${jdk8}"]) {
+        bat 'mvn -v'
+      }
+    }
+  }
+},
+"ubuntu-22-amd64-maven-11": {
+  stage('Test specific "ubuntu-22-amd64-maven-11" agent label') {
+    node('ubuntu-22-amd64-maven-11') {
+      sh 'java -version'
+      sh 'mvn -v'
+    }
+  }
+},
+"ubuntu-22-amd64-maven-17": {
+  stage('Test specific "ubuntu-22-amd64-maven-17" agent label') {
+    node('ubuntu-22-amd64-maven-17') {
+      sh 'java -version'
+      sh 'mvn -v'
+    }
+  }
+},
+"ubuntu-22-amd64-maven-21": {
+  stage('Test specific "ubuntu-22-amd64-maven-21" agent label') {
+    node('ubuntu-22-amd64-maven-21') {
+      sh 'java -version'
+      sh 'mvn -v'
+    }
+  }
+},
+"win-2019-amd64-maven-11": {
+  stage('Test specific "win-2019-amd64-maven-11" agent label') {
+    node('win-2019-amd64-maven-11') {
+      bat 'java -version'
+      bat 'mvn -v'
+    }
+  }
+},
+"win-2019-amd64-maven-17": {
+  stage('Test specific "win-2019-amd64-maven-17" agent label') {
+    node('win-2019-amd64-maven-17') {
+      bat 'java -version'
+      bat 'mvn -v'
+    }
+  }
+},
+"win-2019-amd64-maven-21": {
+  stage('Test specific "win-2019-amd64-maven-21" agent label') {
+    node('win-2019-amd64-maven-21') {
+      bat 'java -version'
+      bat 'mvn -v'
+    }
+  }
+},
+"win-2025-amd64-maven-25": {
+  stage('Test specific "win-2025-amd64-maven-25" agent label') {
+    node('win-2025-amd64-maven-25') {
+      bat 'java -version'
+      bat 'mvn -v'
+    }
+  }
+}

--- a/cert.ci.jenkins.io/README.adoc
+++ b/cert.ci.jenkins.io/README.adoc
@@ -1,0 +1,4 @@
+= Pipeline Job used by the Infra Team to validate agent allocation on cert.ci.jenkins.io
+
+This test allocates each of the agent types and performs a trivial step on the agent.
+Timeout fails the job if it does not complete within half an hour.

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -72,8 +72,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -83,8 +83,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -94,8 +94,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -105,8 +105,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -116,8 +116,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -127,8 +127,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 },
@@ -138,8 +138,8 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
-      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
+      pwsh 'Get-CimInstance Win32_Processor | Out-String'
+      pwsh 'Get-ComputerInfo | Out-String'
     }
   }
 }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -1,0 +1,131 @@
+parallel "linux": {
+  stage('Test default "linux" agent label with tools') {
+    node('linux') {
+      sh 'java -version'
+      sh 'mvn -v'
+      
+      jdk21 = tool name: "jdk21", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk21}/bin", "JAVA_HOME=${jdk21}"]) {
+        sh 'mvn -v'
+      }
+
+      jdk17 = tool name: "jdk17", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk17}/bin", "JAVA_HOME=${jdk17}"]) {
+        sh 'mvn -v'
+      }
+
+      jdk11 = tool name: "jdk11", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk11}/bin", "JAVA_HOME=${jdk11}"]) {
+        sh 'mvn -v'
+      }
+    
+      jdk8 = tool name: "jdk8", type: 'jdk'
+      withEnv(["PATH+JDK=${jdk8}/bin", "JAVA_HOME=${jdk8}"]) {
+          sh 'mvn -v'
+      }
+    }
+  }
+},
+"ubuntu-22-amd64-maven-11": {
+  stage('Test specific "ubuntu-22-amd64-maven-11" agent label') {
+    node('ubuntu-22-amd64-maven-11') {
+      sh 'java -version'
+      sh 'mvn -v'
+      sh 'cat /proc/cpuinfo'
+      sh 'docker info'
+    }
+  }
+},
+"ubuntu-22-amd64-maven-17": {
+  stage('Test specific "ubuntu-22-amd64-maven-17" agent label') {
+    node('ubuntu-22-amd64-maven-17') {
+      sh 'java -version'
+      sh 'mvn -v'
+      sh 'cat /proc/cpuinfo'
+      sh 'docker info'
+    }
+  }
+},
+"ubuntu-22-amd64-maven-21": {
+  stage('Test specific "ubuntu-22-amd64-maven-21" agent label') {
+    node('ubuntu-22-amd64-maven-21') {
+      sh 'java -version'
+      sh 'mvn -v'
+      sh 'cat /proc/cpuinfo'
+      sh 'docker info'
+    }
+  }
+},
+"ubuntu-22-arm64-maven-21": {
+  stage('Test specific "ubuntu-22-arm64-maven-21" agent label') {
+    node('ubuntu-22-arm64-maven-21') {
+      sh 'java -version'
+      sh 'mvn -v'
+      sh 'cat /proc/cpuinfo'
+      sh 'docker info'
+    }
+  }
+},
+"win-2019-amd64-maven-11": {
+  stage('Test specific "win-2019-amd64-maven-11" agent label') {
+    node('win-2019-amd64-maven-11') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+},
+"win-2019-amd64-maven-17": {
+  stage('Test specific "win-2019-amd64-maven-17" agent label') {
+    node('win-2019-amd64-maven-17') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+},
+"win-2019-amd64-maven-21": {
+  stage('Test specific "win-2019-amd64-maven-21" agent label') {
+    node('win-2019-amd64-maven-21') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+},
+"win-2022-amd64-maven-11": {
+  stage('Test specific "win-2022-amd64-maven-11" agent label') {
+    node('win-2022-amd64-maven-11') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+},
+"win-2022-amd64-maven-17": {
+  stage('Test specific "win-2022-amd64-maven-17" agent label') {
+    node('win-2022-amd64-maven-17') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+},
+"win-2022-amd64-maven-21": {
+  stage('Test specific "win-2022-amd64-maven-21" agent label') {
+    node('win-2022-amd64-maven-21') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+},
+"win-2025-amd64-maven-25": {
+  stage('Test specific "win-2025-amd64-maven-25" agent label') {
+    node('win-2025-amd64-maven-25') {
+      bat 'java -version'
+      bat 'mvn -v'
+      bat 'docker info'
+    }
+  }
+}

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -73,6 +73,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -83,6 +84,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -93,6 +95,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -103,6 +106,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -113,6 +117,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -123,6 +128,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 },
@@ -133,6 +139,7 @@ parallel "linux": {
       bat 'mvn -v'
       bat 'docker info'
       pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
+      pwsh 'Get-ComputerInfo | Select-Object OsName, OsBuildNumber, WindowsVersion'
     }
   }
 }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -72,6 +72,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 },
@@ -81,6 +82,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 },
@@ -90,6 +92,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 },
@@ -99,6 +102,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 },
@@ -108,6 +112,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 },
@@ -117,6 +122,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 },
@@ -126,6 +132,7 @@ parallel "linux": {
       bat 'java -version'
       bat 'mvn -v'
       bat 'docker info'
+      pwsh 'Get-CimInstance Win32_Processor | Select-Object DeviceID, Manufacturer, Name, NumberOfCores, NumberOfLogicalProcessors'
     }
   }
 }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -31,8 +31,8 @@ parallel "linux": {
     node('ubuntu-22-amd64-maven-11') {
       sh 'java -version'
       sh 'mvn -v'
-      sh 'cat /proc/cpuinfo'
       sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },
@@ -41,8 +41,8 @@ parallel "linux": {
     node('ubuntu-22-amd64-maven-17') {
       sh 'java -version'
       sh 'mvn -v'
-      sh 'cat /proc/cpuinfo'
       sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },
@@ -51,8 +51,8 @@ parallel "linux": {
     node('ubuntu-22-amd64-maven-21') {
       sh 'java -version'
       sh 'mvn -v'
-      sh 'cat /proc/cpuinfo'
       sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },
@@ -61,8 +61,8 @@ parallel "linux": {
     node('ubuntu-22-arm64-maven-21') {
       sh 'java -version'
       sh 'mvn -v'
-      sh 'cat /proc/cpuinfo'
       sh 'docker info'
+      sh 'cat /proc/cpuinfo'
     }
   }
 },

--- a/trusted.ci.jenkins.io/README.adoc
+++ b/trusted.ci.jenkins.io/README.adoc
@@ -1,0 +1,4 @@
+= Pipeline Job used by the Infra Team to validate agent allocation on trusted.ci.jenkins.io
+
+This test allocates each of trusted.ci.jenkins.io agent types and performs a trivial step on the agent.
+Timeout fails the job if it does not complete within half an hour.


### PR DESCRIPTION
This change imports existing https://cert.ci.jenkins.io/view/Top-Level%20Items/job/Infra-Team-Validate-Agents & https://cert.ci.jenkins.io/view/Top-Level%20Items/job/Infra-Team-Validate-Agents pipelines, as code in this repository, with one folder for each controller.

> [!NOTE]
> ci.jenkins.io is using trusted.ci.jenkins.io pipeline as it's the pair of controllers used for CI/CD of docker images

It also adds `docker info`, and align CPU and OS info across Linux & Windows and both controllers.

- Raw import of the pipelines: https://github.com/jenkins-infra/acceptance-tests/pull/45/commits/e88f5c5e13aa8b59a56bb0cec359862dbbe446e9
- Changes: https://github.com/jenkins-infra/acceptance-tests/pull/45/changes/e88f5c5e13aa8b59a56bb0cec359862dbbe446e9..HEAD
  - Add CPU info for Windows: https://github.com/jenkins-infra/acceptance-tests/pull/45/commits/304a847b333542f8b76da71e6ae62d4252b95060 [^1]
  - Add OS info for Windows: https://github.com/jenkins-infra/acceptance-tests/pull/45/commits/8b6c34ae3e7533230810edded1f76ca34da3fab4 [^1]
  - Put `docker info` just after `mvn -v` to regroup "apps" checks before "host" checks: https://github.com/jenkins-infra/acceptance-tests/pull/45/commits/b53e4bb938e08988dc295c288ca16f458c690bfc
  - Port those changes to cert.ci.jenkins.io pipeline: https://github.com/jenkins-infra/acceptance-tests/pull/45/commits/be354ef225cdbfc5013a95ef1df680c93590e7ad
  - Show full output of PowerShell info commands instead of enumerating/hardcoding only some: https://github.com/jenkins-infra/acceptance-tests/pull/45/commits/20ce9e8f7d05df399195a0a3c98e280ead32b7ae
  
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4791#issuecomment-3737354371

#### Testing done

- Replay on trusted.ci.jenkins.io: https://trusted.ci.jenkins.io/job/Infra-Team-Validate-Agents/573/ ✅ 
- Replay on cert.ci.jenkins.io: https://cert.ci.jenkins.io/view/Top-Level%20Items/job/Infra-Team-Validate-Agents/574/ ✅ 

[^1]: inspired from the work done for https://github.com/jenkinsci/docker-ssh-agent/pull/581