### PR TITLE
feat: update check-agent-availability to maven 3.9.12

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -2,7 +2,8 @@
 set -eux -o pipefail
 
 DefaultLocale="en_US.utf8"
-DefaultMavenVersion="3.9.11"
+# TODO: track with updatecli
+DefaultMavenVersion="3.9.12"
 DefaultJDKVersion="jdk-21"
 DefaultUser="jenkins"
 


### PR DESCRIPTION
This change updates default Maven version to 3.9.12 in the agents check.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4949