### PR TITLE
feat(acceptance-tests): add `checks.ps1` to default ci.jenkins.io pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,13 +26,13 @@ def generateParallelSteps(labels) {
         def label = unboundLabel // Bind label before the closure
         parallelNodes[label] = {
             node(label) {
-                if (isUnix()) {
+                withEnv(["NODE_LABEL=${label}"]) {
                     checkout scm
-                    withEnv(["NODE_LABEL=${label}"]) {
+                    if (isUnix()) {
                         sh 'bash ./checks.sh "${NODE_LABEL}"'
+                    } else {
+                        pwsh 'pwsh ./checks.ps1 "${env:NODE_LABEL}"'
                     }
-                } else {
-                    pwsh script: './check.ps1 "${env:NODE_LABEL}"'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ def generateParallelSteps(labels) {
     return parallelNodes
 }
 
-timeout(unit: 'MINUTES', time:29) {
+timeout(unit: 'MINUTES', time: 45) {
     for (unboundStage in sequentialStages) {
         def boundStage = unboundStage // Bind label before the closure
         stage(boundStage.key) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-
 sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
 sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
 sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker']
-sequentialStages['Spot and OnDemand'] = [ 'windows && spot', 'windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
+sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ def generateParallelSteps(labels) {
                     if (isUnix()) {
                         sh 'bash ./checks.sh "${NODE_LABEL}"'
                     } else {
-                        pwsh 'pwsh ./checks.ps1 "${env:NODE_LABEL}"'
+                        pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ def generateParallelSteps(labels) {
                         sh 'bash ./checks.sh "${NODE_LABEL}"'
                     }
                 } else {
-                    bat 'set | findstr PROCESSOR'
+                    pwsh script: './check.ps1 "${env:NODE_LABEL}"'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ def generateParallelSteps(labels) {
     return parallelNodes
 }
 
-timeout(unit: 'MINUTES', time: 45) {
+timeout(unit: 'MINUTES', time:29) {
     for (unboundStage in sequentialStages) {
         def boundStage = unboundStage // Bind label before the closure
         stage(boundStage.key) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -22,7 +22,6 @@ if ($args.Count -ge 1 -and $args[0]) {
 
 # System information
 Get-ComputerInfo | Out-String
-Get-CimInstance Win32_Processor | Out-String
 
 # Default locale check
 $currentCulture = [System.Globalization.CultureInfo]::CurrentCulture.Name

--- a/checks.ps1
+++ b/checks.ps1
@@ -109,7 +109,7 @@ if ($label -and $mavenPresent) {
             $jdk = 'jdk-25'
         }
         default {
-            Write-Host "Label '$label' specified. Using default jdk."
+            Write-Host "INFO: Label '$label' specified. Using default jdk."
         }
     }
 
@@ -120,7 +120,7 @@ if ($label -and $mavenPresent) {
         'jdk-21' { $jdknumber = '21' }
         'jdk-25' { $jdknumber = '25' }
         default {
-            Write-Host "ERROR: JDK not matching the expected $jdk for label '$label'"
+            Write-Host "ERROR: JDK does not match the expected $jdk for '$label' label"
             mvn -v
             $failed += 64
             $jdknumber = $null
@@ -133,11 +133,11 @@ if ($label -and $mavenPresent) {
         $jdkFromMaven = $javaLine.ToString().Split(' ')[2]
 
         if ($jdkFromMaven -notmatch [regex]::Escape($jdknumber)) {
-            Write-Host "ERROR: JDK from maven $jdkFromMaven not matching the expected $jdknumber for label '$label'"
+            Write-Host "ERROR: JDK from maven $jdkFromMaven not matching the expected $jdknumber for '$label' label"
             $failed += 64
         }
         else {
-            Write-Host "JDK Version ok $jdkFromMaven for $label"
+            Write-Host "INFO: JDK version $jdkFromMaven from Maven matches '$label' label"
         }
     }
 }
@@ -145,11 +145,11 @@ if ($label -and $mavenPresent) {
 # Maven version check
 $mvnOutput = (mvn -v 2>&1) | Out-String
 if ($mvnOutput -notmatch [regex]::Escape($DefaultMavenVersion)) {
-    Write-Host "ERROR Maven version not matching what is expected : expecting $DefaultMavenVersion for label '$($args[0])' found $mvnOutput"
+    Write-Host "ERROR Maven version not matching what is expected : expecting $DefaultMavenVersion for '$label' label found $mvnOutput"
     $failed += 128
 }
 else {
-    Write-Host "Maven version $DefaultMavenVersion OK for label '$($args[0])'"
+    Write-Host "INFO: Maven version $DefaultMavenVersion matches '$label' label"
 }
 
 # Windows version check
@@ -158,10 +158,10 @@ if ($label) {
     $agentVersion = (Get-ComputerInfo).WindowsProductName -replace '\D'
     if ($labelVersion.length -eq 4) {
         if ($agentVersion -eq $labelVersion) {
-            Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from label $label"
+            Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from '$label' label"
         }
         else {
-            Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match Windows version from label $label"
+            Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match Windows version from '$label' label"
             $failed += 256
         }
     }

--- a/checks.ps1
+++ b/checks.ps1
@@ -27,8 +27,9 @@ Write-Host "INFO: expected default values below"
 $expectedDefaults | Out-String
 
 # System information
+$computerInfo = (Get-ComputerInfo)
 Write-Host "INFO: system information below"
-Get-ComputerInfo | Out-String
+$computerInfo | Out-String
 try {
     Get-CimInstance Win32_Processor | Out-String
 }
@@ -169,7 +170,7 @@ else {
 # Windows version check
 if ($Label) {
     $LabelVersion = $Label -replace '\D'
-    $agentVersion = (Get-ComputerInfo).WindowsProductName -replace '\D'
+    $agentVersion = $computerInfo.WindowsProductName -replace '\D'
     if ($LabelVersion.length -eq 4) {
         if ($agentVersion -eq $LabelVersion) {
             Write-Host ('INFO: Windows {0} version from Get-ComputerInfo matches Windows version from "{1}" label' -f $agentVersion, $Label)

--- a/checks.ps1
+++ b/checks.ps1
@@ -23,6 +23,12 @@ if ($args.Count -ge 1 -and $args[0]) {
 
 # System information
 Get-ComputerInfo | Out-String
+try {
+    Get-CimInstance Win32_Processor | Out-String
+}
+catch {
+    Write-Host "INFO: not enought permissions for calling 'Get-CimInstance Win32_Processor'"
+}
 
 # Default locale check
 $currentCulture = [System.Globalization.CultureInfo]::CurrentCulture.Name

--- a/checks.ps1
+++ b/checks.ps1
@@ -1,0 +1,160 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$DefaultLocale = 'en-US'
+$DefaultMavenVersion = '3.9.12'
+$DefaultJDKVersion = 'jdk-21'
+$DefaultUser = 'jenkins'
+
+# Allow Mark Waite to run the same script on his home network
+if ($env:JENKINS_ADVERTISED_HOSTNAME) {
+    $DefaultUser = 'jagent'
+}
+
+$failed = 0
+$label = ''
+
+if ($args.Count -ge 1 -and $args[0]) {
+    $label = $args[0]
+    Write-Host "label of the node: $label"
+}
+
+# System information
+Get-ComputerInfo | Out-String
+Get-CimInstance Win32_Processor | Out-String
+
+# Default locale check
+$currentCulture = [System.Globalization.CultureInfo]::CurrentCulture.Name
+if ($currentCulture -eq $DefaultLocale) {
+    Write-Host "$DefaultLocale locale is available"
+}
+else {
+    Write-Host "ERROR: $DefaultLocale locale is not available (current: $currentCulture)"
+    $failed += 1
+}
+
+# User existence check
+try {
+    Get-LocalUser -Name $DefaultUser -ErrorAction Stop | Out-Null
+    Write-Host "'$DefaultUser' user exists"
+}
+catch {
+    Write-Host "ERROR: '$DefaultUser' user does not exist"
+    $failed += 2
+}
+
+# Running user check
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+if ($currentUser -notmatch "\\$DefaultUser$") {
+    Write-Host "ERROR: Not running as '$DefaultUser' user"
+    Write-Host "[System.Security.Principal.WindowsIdentity]::GetCurrent().Name: $currentUser"
+    $failed += 4
+}
+
+# Administrator privilege check (should NOT be admin)
+$principal = New-Object Security.Principal.WindowsPrincipal(
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+)
+
+if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Host "ERROR: running as Administrator should not be possible"
+    $failed += 8
+}
+
+# JAVA_HOME check
+if (-not $env:JAVA_HOME) {
+    Write-Host "ERROR: the 'JAVA_HOME' environment variable is undefined"
+    $failed += 16
+}
+
+# Maven CLI check
+try {
+    mvn -v | Out-Null
+}
+catch {
+    Write-Host "ERROR: command 'mvn -v' failed to execute. Debugging informations below:"
+    Write-Host $env:PATH
+    Get-Command mvn -ErrorAction SilentlyContinue
+    mvn -v
+    $failed += 32
+}
+
+# Label-based JDK validation
+if ($label) {
+    $jdk = $DefaultJDKVersion
+
+    switch -Wildcard ($label) {
+        { $_ -like '*maven-8' -or $_ -like '*jdk-8' -or $_ -like '*maven8' } {
+            $jdk = 'jdk-8'
+        }
+        { $_ -like '*maven-11' -or $_ -like '*jdk-11' -or $_ -like '*maven11' } {
+            $jdk = 'jdk-11'
+        }
+        { $_ -like '*maven-17' -or $_ -like '*jdk-17' -or $_ -like '*maven17' } {
+            $jdk = 'jdk-17'
+        }
+        { $_ -like '*maven-21' -or $_ -like '*jdk-21' -or $_ -like '*maven21' } {
+            $jdk = 'jdk-21'
+        }
+        { $_ -like '*maven-25' -or $_ -like '*jdk-25' -or $_ -like '*maven25' } {
+            $jdk = 'jdk-25'
+        }
+        default {
+            Write-Host "Label '$label' specified. Using default jdk."
+        }
+    }
+
+    switch ($jdk) {
+        'jdk-8' { $jdknumber = '1.8' }
+        'jdk-11' { $jdknumber = '11.' }
+        'jdk-17' { $jdknumber = '17.' }
+        'jdk-21' { $jdknumber = '21' }
+        'jdk-25' { $jdknumber = '25' }
+        default {
+            Write-Host "ERROR: JDK not matching the expected $jdk for label '$label'"
+            mvn -v
+            $failed += 64
+            $jdknumber = $null
+        }
+    }
+
+    if ($jdknumber) {
+        $mvnOutput = mvn -v 2>&1
+        $javaLine = $mvnOutput | Select-String 'Java version'
+        $jdkFromMaven = $javaLine.ToString().Split(' ')[2]
+
+        if ($jdkFromMaven -notmatch [regex]::Escape($jdknumber)) {
+            Write-Host "ERROR: JDK from maven $jdkFromMaven not matching the expected $jdknumber for label '$label'"
+            $failed += 64
+        }
+        else {
+            Write-Host "JDK Version ok $jdkFromMaven for $label"
+        }
+    }
+}
+
+# Maven version check
+$mvnOutput = mvn -v 2>&1
+if ($mvnOutput -notmatch [regex]::Escape($DefaultMavenVersion)) {
+    Write-Host "ERROR Maven version not matching what is expected : expecting $DefaultMavenVersion for label '$($args[0])' found $mvnOutput"
+    $failed += 128
+}
+else {
+    Write-Host "Maven version $DefaultMavenVersion OK for label '$($args[0])'"
+}
+
+# Windows version check
+if ($label) {
+    $labelVersion = $label -replace '\D'
+    $agentVersion = Get-ComputerInfo | Select-Object WindowsProductName -replace '\D'
+    if ($labelVersion -eq $agentVersion) {
+        Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from label $label"
+    }
+    else {
+        Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match Windows version from label $label"
+        $failed += 256
+    }
+}
+
+exit $failed

--- a/checks.ps1
+++ b/checks.ps1
@@ -157,7 +157,7 @@ if ($label) {
     $labelVersion = $label -replace '\D'
     $agentVersion = (Get-ComputerInfo).WindowsProductName -replace '\D'
     if ($labelVersion.length -eq 4) {
-        if ($labelVersion -eq $agentVersion) {
+        if ($agentVersion -eq $labelVersion) {
             Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from label $label"
         }
         else {
@@ -166,7 +166,7 @@ if ($label) {
         }
     }
     else {
-        if ($labelVersion -eq $defaultWindowsVersion) {
+        if ($agentVersion -eq $defaultWindowsVersion) {
             Write-Host "Windows $agentVersion version from Get-ComputerInfo matches default Windows $defaultWindowsVersion version"
         }
         else {

--- a/checks.ps1
+++ b/checks.ps1
@@ -1,27 +1,33 @@
 #!/usr/bin/env pwsh
+[CmdletBinding()]
+Param(
+    [Parameter(Position = 1)]
+    [String] $Label
+)
+
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$DefaultLocale = 'en-US'
-$DefaultMavenVersion = '3.9.12'
-$DefaultJDKVersion = 'jdk-21'
-$defaultWindowsVersion = '2025'
-$DefaultUser = 'jenkins'
+$failed = 0
+$expectedDefaults = @{
+    locale         = 'en-US'
+    mavenVersion   = '3.9.12'
+    jdkVersion     = 21
+    windowsVersion = 2025
+    user           = 'jenkins'
+}
 
 # Allow Mark Waite to run the same script on his home network
 if ($env:JENKINS_ADVERTISED_HOSTNAME) {
-    $DefaultUser = 'jagent'
+    $expectedDefaults.user = 'jagent'
 }
 
-$failed = 0
-$label = ''
-
-if ($args.Count -ge 1 -and $args[0]) {
-    $label = $args[0]
-    Write-Host "label of the node: $label"
-}
+Write-Host "INFO: Label passed in parameter: $Label"
+Write-Host "INFO: expected default values below"
+$expectedDefaults | Out-String
 
 # System information
+Write-Host "INFO: system information below"
 Get-ComputerInfo | Out-String
 try {
     Get-CimInstance Win32_Processor | Out-String
@@ -32,145 +38,153 @@ catch {
 
 # Default locale check
 $currentCulture = [System.Globalization.CultureInfo]::CurrentCulture.Name
-if ($currentCulture -eq $DefaultLocale) {
-    Write-Host "$DefaultLocale locale is available"
+if ($currentCulture -eq $expectedDefaults.locale) {
+    Write-Host ('INFO: {0} locale is the expected one' -f $currentCulture)
 }
 else {
-    Write-Host "ERROR: $DefaultLocale locale is not available (current: $currentCulture)"
+    Write-Host ('ERROR: {0} locale is not the expected one' -f $currentCulture, $expectedDefaults.locale)
     $failed += 1
 }
 
 # User existence check
 try {
-    Get-LocalUser -Name $DefaultUser -ErrorAction Stop | Out-Null
-    Write-Host "'$DefaultUser' user exists"
+    Get-LocalUser -Name $expectedDefaults.user -ErrorAction Stop | Out-Null
+    Write-Host ('INFO: "{0}" user exists' -f $expectedDefaults.user)
 }
 catch {
-    Write-Host "ERROR: '$DefaultUser' user does not exist"
+    Write-Host ('ERROR: "{0}" does not exist' -f $expectedDefaults.user)
     $failed += 2
 }
 
 # Running user check
 $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-if ($currentUser -notmatch "\\$DefaultUser$") {
-    Write-Host "ERROR: Not running as '$DefaultUser' user"
-    Write-Host "[System.Security.Principal.WindowsIdentity]::GetCurrent().Name: $currentUser"
+if ($currentUser -match $expectedDefaults.user) {
+    Write-Host ('INFO: Running as "{0}" user' -f $expectedDefaults.user)
+}
+else {
+    Write-Host ('ERROR: Not running as "{0}" user' -f $expectedDefaults.user)
+    Write-Host ('[System.Security.Principal.WindowsIdentity]::GetCurrent().Name: {0}' -f $currentUser)
     $failed += 4
 }
 
 # Administrator privilege check (should NOT be admin)
-$principal = New-Object Security.Principal.WindowsPrincipal(
-    [Security.Principal.WindowsIdentity]::GetCurrent()
-)
-
+$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
 if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    Write-Host "ERROR: running as Administrator should not be possible"
+    Write-Host 'ERROR: Running as Administrator is not expected'
     $failed += 8
+}
+else {
+    Write-Host 'INFO: Not running as Administrator as expected'
 }
 
 # JAVA_HOME check
 if (-not $env:JAVA_HOME) {
-    Write-Host "ERROR: the 'JAVA_HOME' environment variable is undefined"
+    Write-Host 'ERROR: JAVA_HOME environment variable is undefined'
     $failed += 16
+}
+else {
+    Write-Host ('INFO: JAVA_HOME environment variable is defined: {0}' -f $env:JAVA_HOME)
 }
 
 # Maven CLI check
 $mavenPresent = $false
+$mvnOutput = ''
 try {
-    mvn -v | Out-Null
+    $mvnOutput = (mvn -v 2>&1) | Out-String
     $mavenPresent = $true
 }
 catch {
-    Write-Host "ERROR: command 'mvn -v' failed to execute. Debugging informations below:"
+    Write-Host 'ERROR: "mvn -v" command failed to execute. Debugging informations below:'
     Write-Host $env:PATH
     Get-Command mvn -ErrorAction SilentlyContinue
-    mvn -v
+    $mvnOutput = (mvn -v) | Out-String
+    Write-Host $mvnOutput
     $failed += 32
 }
 
 # Label-based JDK validation
-if ($label -and $mavenPresent) {
-    $jdk = $DefaultJDKVersion
+if ($Label -and $mavenPresent) {
+    $jdk = $expectedDefaults.jdkVersion
 
-    switch -Wildcard ($label) {
+    switch -Wildcard ($Label) {
         { $_ -like '*maven-8*' -or $_ -like '*jdk-8*' -or $_ -like '*maven8*' } {
-            $jdk = 'jdk-8'
+            $jdk = 8
         }
         { $_ -like '*maven-11*' -or $_ -like '*jdk-11*' -or $_ -like '*maven11*' } {
-            $jdk = 'jdk-11'
+            $jdk = 11
         }
         { $_ -like '*maven-17*' -or $_ -like '*jdk-17*' -or $_ -like '*maven17*' } {
-            $jdk = 'jdk-17'
+            $jdk = 17
         }
         { $_ -like '*maven-21*' -or $_ -like '*jdk-21*' -or $_ -like '*maven21*' } {
-            $jdk = 'jdk-21'
+            $jdk = 21
         }
         { $_ -like '*maven-25*' -or $_ -like '*jdk-25*' -or $_ -like '*maven25*' } {
-            $jdk = 'jdk-25'
+            $jdk = 25
         }
         default {
-            Write-Host "INFO: Label '$label' specified. Using default jdk."
+            Write-Host ('INFO: "{0}" label does not contain any JDK version. Using default jdk {1}' -f $Label, $jdk)
         }
     }
 
     switch ($jdk) {
-        'jdk-8' { $jdknumber = '1.8' }
-        'jdk-11' { $jdknumber = '11.' }
-        'jdk-17' { $jdknumber = '17.' }
-        'jdk-21' { $jdknumber = '21' }
-        'jdk-25' { $jdknumber = '25' }
+        8  { $jdkVersion = '1.8' }
+        11 { $jdkVersion = '11' }
+        17 { $jdkVersion = '17' }
+        21 { $jdkVersion = '21' }
+        25 { $jdkVersion = '25' }
         default {
-            Write-Host "ERROR: JDK does not match the expected $jdk for '$label' label"
+            Write-Host ('ERROR: JDK{0} does not match the "{1}" label' -f $jdk, $Label)
             mvn -v
             $failed += 64
-            $jdknumber = $null
+            $jdkVersion = $null
         }
     }
 
-    if ($jdknumber) {
-        $mvnOutput = mvn -v 2>&1
-        $javaLine = $mvnOutput | Select-String 'Java version'
+    if ($jdkVersion) {
+        $javaLine = (mvn -v 2>&1) | Select-String 'Java version'
         $jdkFromMaven = $javaLine.ToString().Split(' ')[2]
 
-        if ($jdkFromMaven -notmatch [regex]::Escape($jdknumber)) {
-            Write-Host "ERROR: JDK from maven $jdkFromMaven not matching the expected $jdknumber for '$label' label"
-            $failed += 64
+        if ($jdkFromMaven -match [regex]::Escape($jdkVersion)) {
+            Write-Host ('INFO: JDK{0} from Maven matches the expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
         }
         else {
-            Write-Host "INFO: JDK version $jdkFromMaven from Maven matches '$label' label"
+            Write-Host ('ERROR: JDK{0} from Maven does not match the expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
+            $failed += 64
         }
     }
 }
 
 # Maven version check
-$mvnOutput = (mvn -v 2>&1) | Out-String
-if ($mvnOutput -notmatch [regex]::Escape($DefaultMavenVersion)) {
-    Write-Host "ERROR Maven version not matching what is expected : expecting $DefaultMavenVersion for '$label' label found $mvnOutput"
-    $failed += 128
+if ($mavenPresent -and $mvnOutput -match [regex]::Escape($expectedDefaults.mavenVersion)) {
+    Write-Host ('INFO: Maven output match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
+    Write-Host $mvnOutput
 }
 else {
-    Write-Host "INFO: Maven version $DefaultMavenVersion matches '$label' label"
+    Write-Host ('ERROR: Maven output does not match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
+    Write-Host $mvnOutput
+    $failed += 128
 }
 
 # Windows version check
-if ($label) {
-    $labelVersion = $label -replace '\D'
+if ($Label) {
+    $LabelVersion = $Label -replace '\D'
     $agentVersion = (Get-ComputerInfo).WindowsProductName -replace '\D'
-    if ($labelVersion.length -eq 4) {
-        if ($agentVersion -eq $labelVersion) {
-            Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from '$label' label"
+    if ($LabelVersion.length -eq 4) {
+        if ($agentVersion -eq $LabelVersion) {
+            Write-Host ('INFO: Windows {0} version from Get-ComputerInfo matches Windows version from "{1}" label' -f $agentVersion, $Label)
         }
         else {
-            Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match Windows version from '$label' label"
+            Write-Host ('ERROR: Windows {0} version from Get-ComputerInfo does not match Windows version from "{1}" label' -f $agentVersion, $Label)
             $failed += 256
         }
     }
     else {
-        if ($agentVersion -eq $defaultWindowsVersion) {
-            Write-Host "Windows $agentVersion version from Get-ComputerInfo matches default Windows $defaultWindowsVersion version"
+        if ($agentVersion -eq $expectedDefaults.windowsVersion) {
+            Write-Host ('INFO: Windows {0} version from Get-ComputerInfo matches default Windows {1} version' -f $agentVersion, $expectedDefaults.windowsVersion)
         }
         else {
-            Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match default Windows $defaultWindowsVersion version"
+            Write-Host ('ERROR: Windows {0} version from Get-ComputerInfo does not match default Windows {1} version' -f $agentVersion, $expectedDefaults.windowsVersion)
             $failed += 256
         }
     }

--- a/checks.ps1
+++ b/checks.ps1
@@ -68,8 +68,10 @@ if (-not $env:JAVA_HOME) {
 }
 
 # Maven CLI check
+$mavenPresent = $false
 try {
     mvn -v | Out-Null
+    $mavenPresent = $true
 }
 catch {
     Write-Host "ERROR: command 'mvn -v' failed to execute. Debugging informations below:"
@@ -80,23 +82,23 @@ catch {
 }
 
 # Label-based JDK validation
-if ($label) {
+if ($label -and $mavenPresent) {
     $jdk = $DefaultJDKVersion
 
     switch -Wildcard ($label) {
-        { $_ -like '*maven-8' -or $_ -like '*jdk-8' -or $_ -like '*maven8' } {
+        { $_ -like '*maven-8*' -or $_ -like '*jdk-8*' -or $_ -like '*maven8*' } {
             $jdk = 'jdk-8'
         }
-        { $_ -like '*maven-11' -or $_ -like '*jdk-11' -or $_ -like '*maven11' } {
+        { $_ -like '*maven-11*' -or $_ -like '*jdk-11*' -or $_ -like '*maven11*' } {
             $jdk = 'jdk-11'
         }
-        { $_ -like '*maven-17' -or $_ -like '*jdk-17' -or $_ -like '*maven17' } {
+        { $_ -like '*maven-17*' -or $_ -like '*jdk-17*' -or $_ -like '*maven17*' } {
             $jdk = 'jdk-17'
         }
-        { $_ -like '*maven-21' -or $_ -like '*jdk-21' -or $_ -like '*maven21' } {
+        { $_ -like '*maven-21*' -or $_ -like '*jdk-21*' -or $_ -like '*maven21*' } {
             $jdk = 'jdk-21'
         }
-        { $_ -like '*maven-25' -or $_ -like '*jdk-25' -or $_ -like '*maven25' } {
+        { $_ -like '*maven-25*' -or $_ -like '*jdk-25*' -or $_ -like '*maven25*' } {
             $jdk = 'jdk-25'
         }
         default {
@@ -134,7 +136,7 @@ if ($label) {
 }
 
 # Maven version check
-$mvnOutput = mvn -v 2>&1
+$mvnOutput = (mvn -v 2>&1) | Out-String
 if ($mvnOutput -notmatch [regex]::Escape($DefaultMavenVersion)) {
     Write-Host "ERROR Maven version not matching what is expected : expecting $DefaultMavenVersion for label '$($args[0])' found $mvnOutput"
     $failed += 128
@@ -146,7 +148,7 @@ else {
 # Windows version check
 if ($label) {
     $labelVersion = $label -replace '\D'
-    $agentVersion = Get-ComputerInfo | Select-Object WindowsProductName -replace '\D'
+    $agentVersion = (Get-ComputerInfo).WindowsProductName -replace '\D'
     if ($labelVersion -eq $agentVersion) {
         Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from label $label"
     }

--- a/checks.ps1
+++ b/checks.ps1
@@ -5,6 +5,7 @@ Set-StrictMode -Version Latest
 $DefaultLocale = 'en-US'
 $DefaultMavenVersion = '3.9.12'
 $DefaultJDKVersion = 'jdk-21'
+$defaultWindowsVersion = '2025'
 $DefaultUser = 'jenkins'
 
 # Allow Mark Waite to run the same script on his home network
@@ -149,12 +150,23 @@ else {
 if ($label) {
     $labelVersion = $label -replace '\D'
     $agentVersion = (Get-ComputerInfo).WindowsProductName -replace '\D'
-    if ($labelVersion -eq $agentVersion) {
-        Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from label $label"
+    if ($labelVersion.length -eq 4) {
+        if ($labelVersion -eq $agentVersion) {
+            Write-Host "Windows $agentVersion version from Get-ComputerInfo matches Windows version from label $label"
+        }
+        else {
+            Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match Windows version from label $label"
+            $failed += 256
+        }
     }
     else {
-        Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match Windows version from label $label"
-        $failed += 256
+        if ($labelVersion -eq $defaultWindowsVersion) {
+            Write-Host "Windows $agentVersion version from Get-ComputerInfo matches default Windows $defaultWindowsVersion version"
+        }
+        else {
+            Write-Host "ERROR: Windows $agentVersion version from Get-ComputerInfo does not match default Windows $defaultWindowsVersion version"
+            $failed += 256
+        }
     }
 }
 


### PR DESCRIPTION
This change adds a PowerShell script equivalent to the existing checks.sh, and calls it from ci.jenkins.io pipeline.

This script has an additional check: proper Windows version.

```
[2026-01-28T12:45:43.353Z] INFO: Label passed in parameter: maven-11-windows
[2026-01-28T12:45:43.355Z] INFO: expected default values below
[2026-01-28T12:45:43.355Z] 
[2026-01-28T12:45:43.356Z] Name                           Value
[2026-01-28T12:45:43.357Z] ----                           -----
[2026-01-28T12:45:43.357Z] user                           jenkins
[2026-01-28T12:45:43.358Z] windowsVersion                 2025
[2026-01-28T12:45:43.359Z] jdkVersion                     21
[2026-01-28T12:45:43.359Z] locale                         en-US
[2026-01-28T12:45:43.360Z] mavenVersion                   3.9.12
[2026-01-28T12:45:43.361Z] 
[2026-01-28T12:45:43.361Z] 
[2026-01-28T12:45:43.361Z] INFO: system information below
[2026-01-28T12:46:53.766Z] 
[2026-01-28T12:46:53.766Z] WindowsBuildLabEx                                       : 26100.32230.amd64fre.lt_release_svc_prod1.260110-0031
[2026-01-28T12:46:53.767Z] WindowsCurrentVersion                                   : 6.3
[2026-01-28T12:46:53.768Z] WindowsEditionId                                        : ServerDatacenter
[2026-01-28T12:46:53.768Z] WindowsInstallationType                                 : Server Core
[2026-01-28T12:46:53.768Z] WindowsInstallDateFromRegistry                          : 1/28/2026 12:37:09 PM
[2026-01-28T12:46:53.768Z] WindowsProductId                                        : 00491-50000-00001-AA796
[2026-01-28T12:46:53.769Z] WindowsProductName                                      : Windows Server 2025 Datacenter
[2026-01-28T12:46:53.770Z] WindowsRegisteredOrganization                           : Amazon.com
[2026-01-28T12:46:53.770Z] WindowsRegisteredOwner                                  : EC2
[2026-01-28T12:46:53.770Z] WindowsSystemRoot                                       : C:\Windows
[2026-01-28T12:46:53.771Z] WindowsVersion                                          : 2009
<...snip...>
[2026-01-28T12:46:53.968Z] DeviceGuardCodeIntegrityPolicyEnforcementStatus         : 
[2026-01-28T12:46:53.968Z] DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus : [2026-01-28T12:46:53.968Z] 
[2026-01-28T12:46:53.968Z] 
[2026-01-28T12:46:59.355Z] INFO: not enought permissions for calling 'Get-CimInstance Win32_Processor'
[2026-01-28T12:46:59.356Z] INFO: en-US locale is the expected one
[2026-01-28T12:47:02.936Z] INFO: "jenkins" user exists
[2026-01-28T12:47:02.937Z] INFO: Running as "jenkins" user
[2026-01-28T12:47:03.061Z] INFO: Not running as Administrator as expected
[2026-01-28T12:47:03.062Z] INFO: JAVA_HOME environment variable is defined: C:/tools/jdk-11
[2026-01-28T12:47:12.556Z] INFO: JDK11.0.29, from Maven matches the expected JDK11 from "maven-11-windows" label
[2026-01-28T12:47:13.181Z] INFO: Maven output match the expected 3.9.12 version from "maven-11-windows" label:
[2026-01-28T12:47:13.181Z] Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
[2026-01-28T12:47:13.181Z] Maven home: C:\tools\apache-maven-3.9.12
[2026-01-28T12:47:13.181Z] Java version: 11.0.29, vendor: Eclipse Adoptium, runtime: C:\tools\jdk-11
[2026-01-28T12:47:13.182Z] Default locale: en_US, platform encoding: Cp1252
[2026-01-28T12:47:13.182Z] OS name: "windows server 2025", version: "10.0", arch: "amd64", family: "windows"
[2026-01-28T12:47:13.182Z] 
[2026-01-28T12:48:23.315Z] INFO: Windows 2025 version from Get-ComputerInfo matches default Windows 2025 version
```

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3800559559

#### Testing done

https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/PR-48/32/