### PR TITLE
feat(acceptance-tests/trusted.ci): pipeline and checks scripts from ci.jenkins.io

### DIFF
--- a/checks.ps1
+++ b/checks.ps1
@@ -22,7 +22,7 @@ $expectedDefaults = @{
 # Optional checks to perform, not run on every controller or label
 $optionalChecksToPerform = @('jdk', 'mvn', 'admin')
 # Exceptions for trusted.ci.jenkins.io agents
-if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io') {
+if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
     # Windows agents currently run as Administrator
     $optionalChecksToPerform = @('jdk', 'mvn')
     switch ($Label) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -19,26 +19,33 @@ $expectedDefaults = @{
     user           = 'jenkins'
 }
 
+[Flags()]
+enum OptionalCheck {
+    None   = 0
+    Jdk    = 1
+    Maven  = 2
+    Admin  = 4
+    Docker = 8
+}
+
 # Optional checks to perform, not run on every controller or label
-$optionalChecksToPerform = [System.Collections.Generic.List[string]]::new(
-    @('jdk', 'mvn', 'admin')
-)
+$optionalChecks = [OptionalCheck]::Jdk -bor [OptionalCheck]::Maven -bor [OptionalCheck]::Admin
 switch ($Label) {
     { $_ -like '*docker*' } {
-         $optionalChecksToPerform.Add('docker')
+        $optionalChecks = $optionalChecks -bor [OptionalCheck]::Docker
     }
     { $_ -like 'windows*' } {
-         $optionalChecksToPerform.Add('docker')
+        $optionalChecks = $optionalChecks -bor [OptionalCheck]::Docker
     }
 }
 # Exceptions for trusted.ci.jenkins.io agents
 if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
     # Windows agents currently run as Administrator
-    $optionalChecksToPerform.Remove('admin')
+    $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Admin)
     switch ($Label) {
         { $_ -like 'docker' } {
             # Default JDK not as expected
-            $optionalChecksToPerform.Remove('jdk')
+            $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Jdk)
         }
     }
 }
@@ -51,6 +58,7 @@ if ($env:JENKINS_ADVERTISED_HOSTNAME) {
 Write-Host "INFO: Label passed in parameter: $Label"
 Write-Host "INFO: expected default values below"
 Write-Host ($expectedDefaults | Out-String)
+Write-Host "INFO: Optional checks enabled: $optionalChecks"
 
 # System information
 $computerInfo = (Get-ComputerInfo)
@@ -95,7 +103,7 @@ else {
 }
 
 # Administrator privilege check (should NOT be admin)
-if ($optionalChecksToPerform.Contains('admin')) {
+if ($optionalChecks.HasFlag([OptionalCheck]::Admin)) {
     $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
     if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
         Write-Host 'ERROR: Running as Administrator is not expected'
@@ -119,7 +127,7 @@ else {
 
 # Maven CLI check
 $mavenPresent = $false
-if ($optionalChecksToPerform.Contains('mvn')) {
+if ($optionalChecks.HasFlag([OptionalCheck]::Maven)) {
     $mvnOutput = ''
     try {
         $mvnOutput = (mvn -v 2>&1) | Out-String
@@ -138,7 +146,7 @@ if ($optionalChecksToPerform.Contains('mvn')) {
 }
 
 # Label-based JDK validation
-if ($optionalChecksToPerform.Contains('jdk')) {
+if ($optionalChecks.HasFlag([OptionalCheck]::Jdk)) {
     if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
         $jdk = $expectedDefaults.jdkVersion
 
@@ -198,7 +206,7 @@ if ($optionalChecksToPerform.Contains('jdk')) {
 }
 
 # Maven version check
-if ($optionalChecksToPerform.Contains('mvn')) {
+if ($optionalChecks.HasFlag([OptionalCheck]::Maven)) {
     if ($mavenPresent -and $mvnOutput -match [regex]::Escape($expectedDefaults.mavenVersion)) {
         Write-Host ('INFO: Maven output match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
         Write-Host $mvnOutput
@@ -237,7 +245,7 @@ if ($Label) {
 }
 
 # Docker check
-if ($optionalChecksToPerform.Contains('docker')) {
+if ($optionalChecks.HasFlag([OptionalCheck]::Docker)) {
     try {
         $dockerInfo = (docker info) | Out-String
         Write-Host ('INFO: docker is present as expected from "{0}" label, info below' -f $Label)

--- a/checks.ps1
+++ b/checks.ps1
@@ -86,13 +86,17 @@ else {
 }
 
 # Administrator privilege check (should NOT be admin)
-$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    Write-Host 'ERROR: Running as Administrator is not expected'
-    $failed += 8
-}
-else {
-    Write-Host 'INFO: Not running as Administrator as expected'
+if ($optionalChecksToPerform.Contains('admin')) {
+    $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Write-Host 'ERROR: Running as Administrator is not expected'
+        $failed += 8
+    }
+    else {
+        Write-Host 'INFO: Not running as Administrator as expected'
+    }
+} else {
+    Write-Host 'WARNING: Running as Administrator check skipped'
 }
 
 # JAVA_HOME check

--- a/checks.ps1
+++ b/checks.ps1
@@ -20,7 +20,9 @@ $expectedDefaults = @{
 }
 
 # Optional checks to perform, not run on every controller or label
-$optionalChecksToPerform = @('jdk', 'mvn', 'admin')
+$optionalChecksToPerform = [System.Collections.Generic.List[string]]::new(
+    @('jdk', 'mvn', 'admin')
+)
 switch ($Label) {
     { $_ -like '*docker*' } {
          $optionalChecksToPerform.Add('docker')

--- a/checks.ps1
+++ b/checks.ps1
@@ -40,7 +40,7 @@ switch ($Label) {
     }
 }
 # Exceptions for trusted.ci.jenkins.io agents
-if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
+if ($env:JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
     # Windows agents currently run as Administrator
     $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Admin)
     switch ($Label) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -19,11 +19,16 @@ $expectedDefaults = @{
     user           = 'jenkins'
 }
 
-$optionalChecksToPerform = @('jdk', 'mvn')
+# Optional checks to perform, not run on every controller or label
+$optionalChecksToPerform = @('jdk', 'mvn', 'admin')
+# Exceptions for trusted.ci.jenkins.io agents
 if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io') {
+    # Windows agents currently run as Administrator
+    $optionalChecksToPerform = @('jdk', 'mvn')
     switch ($Label) {
-        { $_ -like 'docker' } {
-            $optionalChecksToPerform = @()
+        { $_ -like 'docker-windows' } {
+            # Default JDK not as expected
+            $optionalChecksToPerform = @('mvn')
         }
         Default {}
     }

--- a/checks.ps1
+++ b/checks.ps1
@@ -124,6 +124,8 @@ if ($optionalChecksToPerform.Contains('mvn')) {
         Write-Host $mvnOutput
         $failed += 32
     }
+} else {
+    Write-Host 'WARNING: "mvn -v" check skipped'
 }
 
 # Label-based JDK validation
@@ -182,6 +184,8 @@ if ($optionalChecksToPerform.Contains('jdk')) {
             }
         }
     }
+} else {
+    Write-Host 'WARNING: Expected JDK check skipped'
 }
 
 # Maven version check
@@ -195,6 +199,8 @@ if ($optionalChecksToPerform.Contains('mvn')) {
         Write-Host $mvnOutput
         $failed += 128
     }
+} else {
+    Write-Host 'WARNING: Expected Maven output check skipped'
 }
 
 # Windows version check

--- a/checks.ps1
+++ b/checks.ps1
@@ -21,16 +21,23 @@ $expectedDefaults = @{
 
 # Optional checks to perform, not run on every controller or label
 $optionalChecksToPerform = @('jdk', 'mvn', 'admin')
+switch ($Label) {
+    { $_ -like '*docker*' } {
+         $optionalChecksToPerform.Add('docker')
+    }
+    { $_ -like 'windows*' } {
+         $optionalChecksToPerform.Add('docker')
+    }
+}
 # Exceptions for trusted.ci.jenkins.io agents
 if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
     # Windows agents currently run as Administrator
-    $optionalChecksToPerform = @('jdk', 'mvn')
+    $optionalChecksToPerform.Remove('admin')
     switch ($Label) {
         { $_ -like 'docker-windows' } {
             # Default JDK not as expected
-            $optionalChecksToPerform = @('mvn')
+            $optionalChecksToPerform.Remove('jdk')
         }
-        Default {}
     }
 }
 
@@ -228,19 +235,7 @@ if ($Label) {
 }
 
 # Docker check
-$dockerExpected = $false
-switch -Wildcard ($Label) {
-    { $_ -like '*docker*' } {
-        $dockerExpected = $true
-    }
-    { $_ -like 'windows*' } {
-        $dockerExpected = $true
-    }
-    default {
-        Write-Host ('INFO: docker is not expected from "{0}" label' -f $Label)
-    }
-}
-if ($dockerExpected) {
+if ($optionalChecksToPerform.Contains('docker')) {
     try {
         $dockerInfo = (docker info) | Out-String
         Write-Host ('INFO: docker is present as expected from "{0}" label, info below' -f $Label)
@@ -253,6 +248,8 @@ if ($dockerExpected) {
         $dockerInfo = (docker info) | Out-String
         $failed += 1024
     }
+} else {
+    Write-Host 'WARNING: Docker check skipped'
 }
 
 exit $failed

--- a/checks.ps1
+++ b/checks.ps1
@@ -19,6 +19,16 @@ $expectedDefaults = @{
     user           = 'jenkins'
 }
 
+$optionalChecksToPerform = @('jdk', 'mvn')
+if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io') {
+    switch ($Label) {
+        { $_ -like 'docker' } {
+            $optionalChecksToPerform = @()
+        }
+        Default {}
+    }
+}
+
 # Allow Mark Waite to run the same script on his home network
 if ($env:JENKINS_ADVERTISED_HOSTNAME) {
     $expectedDefaults.user = 'jagent'
@@ -91,85 +101,91 @@ else {
 
 # Maven CLI check
 $mavenPresent = $false
-$mvnOutput = ''
-try {
-    $mvnOutput = (mvn -v 2>&1) | Out-String
-    $mavenPresent = $true
-}
-catch {
-    Write-Host 'ERROR: "mvn -v" command failed to execute. Debugging informations below:'
-    Write-Host $env:PATH
-    Get-Command mvn -ErrorAction SilentlyContinue
-    $mvnOutput = (mvn -v) | Out-String
-    Write-Host $mvnOutput
-    $failed += 32
+if ($optionalChecksToPerform.Contains('mvn')) {
+    $mvnOutput = ''
+    try {
+        $mvnOutput = (mvn -v 2>&1) | Out-String
+        $mavenPresent = $true
+    }
+    catch {
+        Write-Host 'ERROR: "mvn -v" command failed to execute. Debugging informations below:'
+        Write-Host $env:PATH
+        Get-Command mvn -ErrorAction SilentlyContinue
+        $mvnOutput = (mvn -v) | Out-String
+        Write-Host $mvnOutput
+        $failed += 32
+    }
 }
 
 # Label-based JDK validation
-if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
-    $jdk = $expectedDefaults.jdkVersion
+if ($optionalChecksToPerform.Contains('jdk')) {
+    if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
+        $jdk = $expectedDefaults.jdkVersion
 
-    switch -Wildcard ($Label) {
-        { $_ -like '*maven-8*' -or $_ -like '*jdk-8*' -or $_ -like '*maven8*' } {
-            $jdk = 8
-        }
-        { $_ -like '*maven-11*' -or $_ -like '*jdk-11*' -or $_ -like '*maven11*' } {
-            $jdk = 11
-        }
-        { $_ -like '*maven-17*' -or $_ -like '*jdk-17*' -or $_ -like '*maven17*' } {
-            $jdk = 17
-        }
-        { $_ -like '*maven-21*' -or $_ -like '*jdk-21*' -or $_ -like '*maven21*' } {
-            $jdk = 21
-        }
-        { $_ -like '*maven-25*' -or $_ -like '*jdk-25*' -or $_ -like '*maven25*' } {
-            $jdk = 25
-        }
-        default {
-            Write-Host ('INFO: "{0}" label does not contain any JDK version. Using default jdk {1}' -f $Label, $jdk)
-        }
-    }
-
-    switch ($jdk) {
-        8  { $jdkVersion = '1.8' }
-        11 { $jdkVersion = '11' }
-        17 { $jdkVersion = '17' }
-        21 { $jdkVersion = '21' }
-        25 { $jdkVersion = '25' }
-        default {
-            Write-Host ('ERROR: JDK{0} does not match the "{1}" label' -f $jdk, $Label)
-            mvn -v
-            $failed += 64
-            $jdkVersion = $null
-        }
-    }
-
-    if ($jdkVersion) {
-        $jdkFromMaven = ''
-        $javaLine = (mvn -v 2>&1 | Select-String 'Java version').Line -replace ',', ''
-        if ($javaLine -match 'Java version:\s*([^\s,]+)') {
-            $jdkFromMaven = $Matches[1]
+        switch -Wildcard ($Label) {
+            { $_ -like '*maven-8*' -or $_ -like '*jdk-8*' -or $_ -like '*maven8*' } {
+                $jdk = 8
+            }
+            { $_ -like '*maven-11*' -or $_ -like '*jdk-11*' -or $_ -like '*maven11*' } {
+                $jdk = 11
+            }
+            { $_ -like '*maven-17*' -or $_ -like '*jdk-17*' -or $_ -like '*maven17*' } {
+                $jdk = 17
+            }
+            { $_ -like '*maven-21*' -or $_ -like '*jdk-21*' -or $_ -like '*maven21*' } {
+                $jdk = 21
+            }
+            { $_ -like '*maven-25*' -or $_ -like '*jdk-25*' -or $_ -like '*maven25*' } {
+                $jdk = 25
+            }
+            default {
+                Write-Host ('INFO: "{0}" label does not contain any JDK version. Using default jdk {1}' -f $Label, $jdk)
+            }
         }
 
-        if ($jdkFromMaven -and $jdkFromMaven -match [regex]::Escape($jdkVersion)) {
-            Write-Host ('INFO: Java version {0} from Maven matches expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
+        switch ($jdk) {
+            8  { $jdkVersion = '1.8' }
+            11 { $jdkVersion = '11' }
+            17 { $jdkVersion = '17' }
+            21 { $jdkVersion = '21' }
+            25 { $jdkVersion = '25' }
+            default {
+                Write-Host ('ERROR: JDK{0} does not match the "{1}" label' -f $jdk, $Label)
+                mvn -v
+                $failed += 64
+                $jdkVersion = $null
+            }
         }
-        else {
-            Write-Host ('ERROR: Java version {0} from Maven does not match expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
-            $failed += 64
+
+        if ($jdkVersion) {
+            $jdkFromMaven = ''
+            $javaLine = (mvn -v 2>&1 | Select-String 'Java version').Line -replace ',', ''
+            if ($javaLine -match 'Java version:\s*([^\s,]+)') {
+                $jdkFromMaven = $Matches[1]
+            }
+
+            if ($jdkFromMaven -and $jdkFromMaven -match [regex]::Escape($jdkVersion)) {
+                Write-Host ('INFO: Java version {0} from Maven matches expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
+            }
+            else {
+                Write-Host ('ERROR: Java version {0} from Maven does not match expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
+                $failed += 64
+            }
         }
     }
 }
 
 # Maven version check
-if ($mavenPresent -and $mvnOutput -match [regex]::Escape($expectedDefaults.mavenVersion)) {
-    Write-Host ('INFO: Maven output match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
-    Write-Host $mvnOutput
-}
-else {
-    Write-Host ('ERROR: Maven output does not match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
-    Write-Host $mvnOutput
-    $failed += 128
+if ($optionalChecksToPerform.Contains('mvn')) {
+    if ($mavenPresent -and $mvnOutput -match [regex]::Escape($expectedDefaults.mavenVersion)) {
+        Write-Host ('INFO: Maven output match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
+        Write-Host $mvnOutput
+    }
+    else {
+        Write-Host ('ERROR: Maven output does not match the expected {0} version from "{1}" label:' -f $expectedDefaults.mavenVersion, $Label)
+        Write-Host $mvnOutput
+        $failed += 128
+    }
 }
 
 # Windows version check

--- a/checks.ps1
+++ b/checks.ps1
@@ -19,6 +19,7 @@ $expectedDefaults = @{
     user           = 'jenkins'
 }
 
+# Optional checks to perform
 [Flags()]
 enum OptionalCheck {
     None   = 0
@@ -28,7 +29,7 @@ enum OptionalCheck {
     Docker = 8
 }
 
-# Optional checks to perform, not run on every controller or label
+# Default optional checks
 $optionalChecks = [OptionalCheck]::Jdk -bor [OptionalCheck]::Maven -bor [OptionalCheck]::Admin
 switch ($Label) {
     { $_ -like '*docker*' } {

--- a/checks.ps1
+++ b/checks.ps1
@@ -36,7 +36,7 @@ if ($env.JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
     # Windows agents currently run as Administrator
     $optionalChecksToPerform.Remove('admin')
     switch ($Label) {
-        { $_ -like 'docker-windows' } {
+        { $_ -like 'docker' } {
             # Default JDK not as expected
             $optionalChecksToPerform.Remove('jdk')
         }

--- a/checks.sh
+++ b/checks.sh
@@ -11,7 +11,7 @@ DefaultUser="jenkins"
 label=''
 if [ $# -ge 1 ] && [ -n "$1" ]; then
 	label="$1"
-	echo "INFO: label of the node: ${label}"
+	echo "INFO: label of the node: '${label}'"
 fi
 
 # Optional checks to perform, not run on every controller or label
@@ -49,14 +49,14 @@ if test -e /proc/meminfo; then
 fi
 
 if [[ "$(locale -a)" =~ ${DefaultLocale} ]]; then
-	echo "${DefaultLocale} locale is available"
+	echo "INFO: ${DefaultLocale} locale is available"
 else
 	echo "ERROR: ${DefaultLocale} locale is not available $(locale -a)"
 	failed=$((failed + 1))
 fi
 
 if getent passwd ${DefaultUser} >/dev/null; then
-	echo "'${DefaultUser}' user exists"
+	echo "INFO: '${DefaultUser}' user exists"
 else
 	echo "ERROR: '${DefaultUser}' user does not exist"
 	failed=$((failed + 2))
@@ -118,7 +118,7 @@ if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
 			*maven-25 | *jdk-25 | *maven25)
 				jdk="jdk-25";;
 			*)
-				echo "Label '${label}' specified. Using default jdk."
+				echo "INFO: Label '${label}' specified. Using default jdk."
 		esac
 
 		case ${jdk} in
@@ -147,7 +147,7 @@ if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
 				failed=$((failed + 64))
 			fi
 		else
-			echo "JDK Version ok ${JDKfromMaven} for ${label}"
+			echo "INFO: JDK Version ok ${JDKfromMaven} for ${label}"
 		fi
 	fi
 else
@@ -159,7 +159,7 @@ if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
 		echo "ERROR Maven version not matching what is expected : expecting ${DefaultMavenVersion} for label '${label}' found $(mvn -v 2>&1)"
 		failed=$((failed + 128))
 	else
-		echo "Maven version ${DefaultMavenVersion} OK for label '${label}'"
+		echo "INFO: Maven version ${DefaultMavenVersion} OK for label '${label}'"
 	fi
 else
 	echo 'WARNING: Expected Maven version check skipped'

--- a/checks.sh
+++ b/checks.sh
@@ -14,11 +14,17 @@ if [ $# -ge 1 ] && [ -n "$1" ]; then
 	echo "INFO: label of the node: ${label}"
 fi
 
-optional_checks_to_perform='mvn jdk'
+# Optional checks to perform, not run on every controller or label
+optional_checks_to_perform='javahome mvn jdk'
+# Exceptions for trusted.ci.jenkins.io agents
 if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io' ]]; then
 	case "${label}" in
-		docker|updatecenter)
-			optional_checks_to_perform='';;
+		docker)
+			# Default JDK not as expected
+            optional_checks_to_perform='javahome mvn';;
+		updatecenter)
+			# No JDK no mvn
+            optional_checks_to_perform='';;
 	esac
 fi
 
@@ -67,12 +73,14 @@ if sudo -n whoami; then
 	failed=$((failed + 8))
 fi
 
-set +u
-if [[ -z "${JAVA_HOME}" ]]; then
-	echo "ERROR: the 'JAVA_HOME' environment variable is undefined"
-	failed=$((failed + 16))
+if [[ "${optional_checks_to_perform}" == *javahome* ]]; then
+	set +u
+	if [[ -z "${JAVA_HOME}" ]]; then
+		echo "ERROR: the 'JAVA_HOME' environment variable is undefined"
+		failed=$((failed + 16))
+	fi
+	set -u
 fi
-set -u
 
 # Check for Maven CLI
 if [[ "${optional_checks_to_perform}" == *mvn* ]]; then

--- a/checks.sh
+++ b/checks.sh
@@ -14,25 +14,38 @@ if [ $# -ge 1 ] && [ -n "$1" ]; then
 	echo "INFO: label of the node: '${label}'"
 fi
 
+# Optional check bitmask flags
+CHECK_NONE=0
+CHECK_JAVAHOME=1
+CHECK_MAVEN=2
+CHECK_JDK=4
+CHECK_DOCKER=8
+
 # Optional checks to perform, not run on every controller or label
-optional_checks_to_perform='javahome mvn jdk'
+optional_checks=$((CHECK_JAVAHOME | CHECK_MAVEN | CHECK_JDK))
 case "${label}" in
 	*docker*)
-		optional_checks_to_perform='javahome mvn jdk docker';;
+		optional_checks=$((optional_checks | CHECK_DOCKER));;
 	linux)
-		optional_checks_to_perform='javahome mvn jdk docker';; # docker controller and agents
+		optional_checks=$((optional_checks | CHECK_DOCKER));; # docker controller and agents
 esac
 # Exceptions for trusted.ci.jenkins.io agents
 if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
 	case "${label}" in
 		docker|linux)
 			# Default JDK not as expected
-            optional_checks_to_perform='javahome mvn docker';;
+            optional_checks=$((optional_checks & ~CHECK_JDK));;
 		updatecenter|agent-1)
-			# No JDK no mvn
-            optional_checks_to_perform='';;
+			# No optional check
+            optional_checks=$((CHECK_NONE));;
 	esac
 fi
+
+has_check() {
+    (( optional_checks & $1 ))
+}
+
+echo "INFO: Optional checks bitmask: ${optional_checks}"
 
 # Allow Mark Waite to run the same script on his home network
 if [ -v JENKINS_ADVERTISED_HOSTNAME ]; then
@@ -79,7 +92,7 @@ if sudo -n whoami; then
 	failed=$((failed + 8))
 fi
 
-if [[ "${optional_checks_to_perform}" == *javahome* ]]; then
+if has_check CHECK_JAVAHOME; then
 	set +u
 	if [[ -z "${JAVA_HOME}" ]]; then
 		echo "ERROR: the 'JAVA_HOME' environment variable is undefined"
@@ -91,7 +104,7 @@ else
 fi
 
 # Check for Maven CLI
-if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
+if has_check CHECK_MAVEN; then
 	mvn -v 2>/dev/null >/dev/null || {
 		set +e
 		echo "ERROR: command 'mvn -v' failed to execute. Debugging informations below:";
@@ -109,7 +122,7 @@ fi
 # Java 8 needs to include '1.8' in the output
 # Java 11 needs to include '11.' in the output
 # Java 17 needs to include '17.' in the output
-if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
+if has_check CHECK_JDK; then
 	if [ -n "${label}" ]; then
 		jdk="${DefaultJDKVersion}"
 		case "${label}" in
@@ -156,7 +169,7 @@ else
 	echo 'WARNING: Expected JDK check skipped'
 fi
 
-if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
+if has_check CHECK_MAVEN; then
 	if [[ "$(mvn -v 2>&1)" != *"${DefaultMavenVersion}"* ]]; then
 		echo "ERROR Maven version not matching what is expected : expecting ${DefaultMavenVersion} for label '${label}' found $(mvn -v 2>&1)"
 		failed=$((failed + 128))
@@ -168,7 +181,7 @@ else
 fi
 
 # Docker check
-if [[ "${optional_checks_to_perform}" == *docker* ]]; then
+if has_check CHECK_DOCKER; then
 	docker info 2>/dev/null >/dev/null && echo "INFO: docker is present as expected from \"${label}\" label" || {
 		echo "ERROR: docker is not present as expected from \"${label}\" label, debugging informations below"
 		set +e

--- a/checks.sh
+++ b/checks.sh
@@ -8,6 +8,20 @@ DefaultMavenVersion="3.9.12"
 DefaultJDKVersion="jdk-21"
 DefaultUser="jenkins"
 
+label=''
+if [ $# -ge 1 ] && [ -n "$1" ]; then
+	label="$1"
+	echo "INFO: label of the node: ${label}"
+fi
+
+optional_checks_to_perform='mvn jdk'
+if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io' ]]; then
+	case "${label}" in
+		docker)
+			optional_checks_to_perform='';;
+	esac
+fi
+
 # Allow Mark Waite to run the same script on his home network
 if [ -v JENKINS_ADVERTISED_HOSTNAME ]; then
 	DefaultUser="jagent"
@@ -61,80 +75,84 @@ fi
 set -u
 
 # Check for Maven CLI
-mvn -v 2>/dev/null >/dev/null || {
-	set +e
-	echo "ERROR: command 'mvn -v' failed to execute. Debugging informations below:";
-	echo "${PATH}";
-	which mvn;
-	mvn -v;
-	set -e
-	exit 1;
-}
-
-label=''
-if [ $# -ge 1 ] && [ -n "$1" ]; then
-	label="$1"
+if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
+	mvn -v 2>/dev/null >/dev/null || {
+		set +e
+		echo "ERROR: command 'mvn -v' failed to execute. Debugging informations below:";
+		echo "${PATH}";
+		which mvn;
+		mvn -v;
+		set -e
+		exit 1;
+	}
 fi
+
 # This check relies on the java version output of the 'mvn -v' command
 # Java 8 needs to include '1.8' in the output
 # Java 11 needs to include '11.' in the output
 # Java 17 needs to include '17.' in the output
-if [ -n "${label}" ]; then
-	echo "label of the node: $1"
+if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
+	if [ -n "${label}" ]; then
+		jdk="${DefaultJDKVersion}"
+		case "${label}" in
+		*maven-8 | *jdk-8 | *maven8)
+			jdk="jdk-8";;
+		*maven-11 | *jdk-11 | *maven11)
+			jdk="jdk-11";;
+		*maven-17 | *jdk-17 | *maven17)
+			jdk="jdk-17";;
+		*maven-21 | *jdk-21 | *maven21)
+			jdk="jdk-21";;
+		*maven-25 | *jdk-25 | *maven25)
+			jdk="jdk-25";;
+		*)
+			echo "Label '${label}' specified. Using default jdk."
+		esac
 
-	jdk="${DefaultJDKVersion}"
-	case "$1" in
-	*maven-8 | *jdk-8 | *maven8)
-		jdk="jdk-8";;
-	*maven-11 | *jdk-11 | *maven11)
-		jdk="jdk-11";;
-	*maven-17 | *jdk-17 | *maven17)
-		jdk="jdk-17";;
-	*maven-21 | *jdk-21 | *maven21)
-		jdk="jdk-21";;
-	*maven-25 | *jdk-25 | *maven25)
-		jdk="jdk-25";;
-	*)
-		echo "Label '$1' specified. Using default jdk."
-	esac
+		case ${jdk} in
+		jdk-8)
+			jdknumber="1.8"
+			;;
+		jdk-11)
+			jdknumber="11."
+			;;
+		jdk-17)
+			jdknumber="17."
+			;;
+		jdk-21)
+			jdknumber="21"
+			;;
+		jdk-25)
+			jdknumber="25"
+			;;
+		*)
+			echo "ERROR: JDK not matching the expected ${jdk} for label '${label}'"
+			mvn -v 2>&1
+			failed=$((failed + 64))
+			;;
+		esac
 
-	case ${jdk} in
-	jdk-8)
-		jdknumber="1.8"
-		;;
-	jdk-11)
-		jdknumber="11."
-		;;
-	jdk-17)
-		jdknumber="17."
-		;;
-	jdk-21)
-		jdknumber="21"
-		;;
-	jdk-25)
-		jdknumber="25"
-		;;
-	*)
-		echo "ERROR: JDK not matching the expected ${jdk} for label '$1'"
-		mvn -v 2>&1
-		failed=$((failed + 64))
-		;;
-	esac
-
-	JDKfromMaven=$(mvn -v 2>&1 | grep "Java version" | cut -d " " -f 3)
-	if [[ "${JDKfromMaven}" != *"${jdknumber}"* ]]; then
-		echo "ERROR: JDK from maven ${JDKfromMaven} not matching the expected ${jdknumber} for label '$1'"
-		failed=$((failed + 64))
-	else
-		echo "JDK Version ok ${JDKfromMaven} for $1"
+		JDKfromMaven=$(mvn -v 2>&1 | grep "Java version" | cut -d " " -f 3)
+		if [[ "${JDKfromMaven}" != *"${jdknumber}"* ]]; then
+			if [[ "${label}" == 'docker' && "${JENKINS_URL}" == "trusted.ci.jenkins.io" ]]; then
+				echo "WARNING: JDK from maven ${JDKfromMaven} not matching the expected ${jdknumber} for label '${label}' on trusted.ci.jenkins.io"
+			else
+				echo "ERROR: JDK from maven ${JDKfromMaven} not matching the expected ${jdknumber} for label '${label}'"
+				failed=$((failed + 64))
+			fi
+		else
+			echo "JDK Version ok ${JDKfromMaven} for ${label}"
+		fi
 	fi
 fi
 
-if [[ "$(mvn -v 2>&1)" != *"${DefaultMavenVersion}"* ]]; then
-	echo "ERROR Maven version not matching what is expected : expecting ${DefaultMavenVersion} for label '$1' found $(mvn -v 2>&1)"
-	failed=$((failed + 128))
-else
-	echo "Maven version ${DefaultMavenVersion} OK for label '$1'"
+if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
+	if [[ "$(mvn -v 2>&1)" != *"${DefaultMavenVersion}"* ]]; then
+		echo "ERROR Maven version not matching what is expected : expecting ${DefaultMavenVersion} for label '${label}' found $(mvn -v 2>&1)"
+		failed=$((failed + 128))
+	else
+		echo "Maven version ${DefaultMavenVersion} OK for label '${label}'"
+	fi
 fi
 
 # Docker check
@@ -145,7 +163,7 @@ case "${label}" in
 	linux)
 		docker_expected=true;; # docker controller and agents
 	*)
-		echo "INFO: docker is not expected from '$1' label"
+		echo "INFO: docker is not expected from '${label}' label"
 esac
 if [[ "${docker_expected}" == "true" ]]; then
 	docker info 2>/dev/null >/dev/null && echo "INFO: docker is present as expected from \"${label}\" label" || {

--- a/checks.sh
+++ b/checks.sh
@@ -140,12 +140,8 @@ if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
 
 		JDKfromMaven=$(mvn -v 2>&1 | grep "Java version" | cut -d " " -f 3)
 		if [[ "${JDKfromMaven}" != *"${jdknumber}"* ]]; then
-			if [[ "${label}" == 'docker' && "${JENKINS_URL}" == "trusted.ci.jenkins.io" ]]; then
-				echo "WARNING: JDK from maven ${JDKfromMaven} not matching the expected ${jdknumber} for label '${label}' on trusted.ci.jenkins.io"
-			else
-				echo "ERROR: JDK from maven ${JDKfromMaven} not matching the expected ${jdknumber} for label '${label}'"
-				failed=$((failed + 64))
-			fi
+			echo "ERROR: JDK from maven ${JDKfromMaven} not matching the expected ${jdknumber} for label '${label}'"
+			failed=$((failed + 64))
 		else
 			echo "INFO: JDK Version ok ${JDKfromMaven} for ${label}"
 		fi

--- a/checks.sh
+++ b/checks.sh
@@ -80,6 +80,8 @@ if [[ "${optional_checks_to_perform}" == *javahome* ]]; then
 		failed=$((failed + 16))
 	fi
 	set -u
+else
+	echo 'WARNING: JAVA_HOME check skipped'
 fi
 
 # Check for Maven CLI
@@ -93,6 +95,8 @@ if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
 		set -e
 		exit 1;
 	}
+else
+	echo 'WARNING: "mvn -v" check skipped'
 fi
 
 # This check relies on the java version output of the 'mvn -v' command
@@ -152,6 +156,8 @@ if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
 			echo "JDK Version ok ${JDKfromMaven} for ${label}"
 		fi
 	fi
+else
+	echo 'WARNING: Expected JDK check skipped'
 fi
 
 if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
@@ -161,6 +167,8 @@ if [[ "${optional_checks_to_perform}" == *mvn* ]]; then
 	else
 		echo "Maven version ${DefaultMavenVersion} OK for label '${label}'"
 	fi
+else
+	echo 'WARNING: Expected Maven version check skipped'
 fi
 
 # Docker check

--- a/checks.sh
+++ b/checks.sh
@@ -107,41 +107,41 @@ if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
 	if [ -n "${label}" ]; then
 		jdk="${DefaultJDKVersion}"
 		case "${label}" in
-		*maven-8 | *jdk-8 | *maven8)
-			jdk="jdk-8";;
-		*maven-11 | *jdk-11 | *maven11)
-			jdk="jdk-11";;
-		*maven-17 | *jdk-17 | *maven17)
-			jdk="jdk-17";;
-		*maven-21 | *jdk-21 | *maven21)
-			jdk="jdk-21";;
-		*maven-25 | *jdk-25 | *maven25)
-			jdk="jdk-25";;
-		*)
-			echo "Label '${label}' specified. Using default jdk."
+			*maven-8 | *jdk-8 | *maven8)
+				jdk="jdk-8";;
+			*maven-11 | *jdk-11 | *maven11)
+				jdk="jdk-11";;
+			*maven-17 | *jdk-17 | *maven17)
+				jdk="jdk-17";;
+			*maven-21 | *jdk-21 | *maven21)
+				jdk="jdk-21";;
+			*maven-25 | *jdk-25 | *maven25)
+				jdk="jdk-25";;
+			*)
+				echo "Label '${label}' specified. Using default jdk."
 		esac
 
 		case ${jdk} in
-		jdk-8)
-			jdknumber="1.8"
-			;;
-		jdk-11)
-			jdknumber="11."
-			;;
-		jdk-17)
-			jdknumber="17."
-			;;
-		jdk-21)
-			jdknumber="21"
-			;;
-		jdk-25)
-			jdknumber="25"
-			;;
-		*)
-			echo "ERROR: JDK not matching the expected ${jdk} for label '${label}'"
-			mvn -v 2>&1
-			failed=$((failed + 64))
-			;;
+			jdk-8)
+				jdknumber="1.8"
+				;;
+			jdk-11)
+				jdknumber="11."
+				;;
+			jdk-17)
+				jdknumber="17."
+				;;
+			jdk-21)
+				jdknumber="21"
+				;;
+			jdk-25)
+				jdknumber="25"
+				;;
+			*)
+				echo "ERROR: JDK not matching the expected ${jdk} for label '${label}'"
+				mvn -v 2>&1
+				failed=$((failed + 64))
+				;;
 		esac
 
 		JDKfromMaven=$(mvn -v 2>&1 | grep "Java version" | cut -d " " -f 3)

--- a/checks.sh
+++ b/checks.sh
@@ -17,7 +17,7 @@ fi
 optional_checks_to_perform='mvn jdk'
 if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io' ]]; then
 	case "${label}" in
-		docker)
+		docker|updatecenter)
 			optional_checks_to_perform='';;
 	esac
 fi

--- a/checks.sh
+++ b/checks.sh
@@ -123,25 +123,19 @@ if [[ "${optional_checks_to_perform}" == *jdk* ]]; then
 
 		case ${jdk} in
 			jdk-8)
-				jdknumber="1.8"
-				;;
+				jdknumber="1.8";;
 			jdk-11)
-				jdknumber="11."
-				;;
+				jdknumber="11.";;
 			jdk-17)
-				jdknumber="17."
-				;;
+				jdknumber="17.";;
 			jdk-21)
-				jdknumber="21"
-				;;
+				jdknumber="21";;
 			jdk-25)
-				jdknumber="25"
-				;;
+				jdknumber="25";;
 			*)
 				echo "ERROR: JDK not matching the expected ${jdk} for label '${label}'"
 				mvn -v 2>&1
 				failed=$((failed + 64))
-				;;
 		esac
 
 		JDKfromMaven=$(mvn -v 2>&1 | grep "Java version" | cut -d " " -f 3)

--- a/checks.sh
+++ b/checks.sh
@@ -28,9 +28,10 @@ case "${label}" in
 		optional_checks=$((optional_checks | CHECK_DOCKER));;
 	linux)
 		optional_checks=$((optional_checks | CHECK_DOCKER));; # docker controller and agents
+	*)
 esac
 # Exceptions for trusted.ci.jenkins.io agents
-if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
+if [[ "${JENKINS_URL:-}" == 'https://trusted.ci.jenkins.io/' ]]; then
 	case "${label}" in
 		docker|linux)
 			# Default JDK not as expected
@@ -38,6 +39,7 @@ if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
 		updatecenter|agent-1)
 			# No optional check
             optional_checks=$((CHECK_NONE));;
+		*)
 	esac
 fi
 

--- a/checks.sh
+++ b/checks.sh
@@ -16,12 +16,18 @@ fi
 
 # Optional checks to perform, not run on every controller or label
 optional_checks_to_perform='javahome mvn jdk'
+case "${label}" in
+	*docker*)
+		optional_checks_to_perform='javahome mvn jdk docker';;
+	linux)
+		optional_checks_to_perform='javahome mvn jdk docker';; # docker controller and agents
+esac
 # Exceptions for trusted.ci.jenkins.io agents
 if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
 	case "${label}" in
 		docker|linux)
 			# Default JDK not as expected
-            optional_checks_to_perform='javahome mvn';;
+            optional_checks_to_perform='javahome mvn docker';;
 		updatecenter)
 			# No JDK no mvn
             optional_checks_to_perform='';;
@@ -162,16 +168,7 @@ else
 fi
 
 # Docker check
-docker_expected=false
-case "${label}" in
-	*docker*)
-		docker_expected=true;;
-	linux)
-		docker_expected=true;; # docker controller and agents
-	*)
-		echo "INFO: docker is not expected from '${label}' label"
-esac
-if [[ "${docker_expected}" == "true" ]]; then
+if [[ "${optional_checks_to_perform}" == *docker* ]]; then
 	docker info 2>/dev/null >/dev/null && echo "INFO: docker is present as expected from \"${label}\" label" || {
 		echo "ERROR: docker is not present as expected from \"${label}\" label, debugging informations below"
 		set +e
@@ -181,6 +178,8 @@ if [[ "${docker_expected}" == "true" ]]; then
 		set -e
 		failed=$((failed + 256))
 	}
+else
+	echo 'WARNING: Docker check skipped'
 fi
 
 exit ${failed}

--- a/checks.sh
+++ b/checks.sh
@@ -21,7 +21,7 @@ CHECK_MAVEN=2
 CHECK_JDK=4
 CHECK_DOCKER=8
 
-# Optional checks to perform, not run on every controller or label
+# Default optional checks
 optional_checks=$((CHECK_JAVAHOME | CHECK_MAVEN | CHECK_JDK))
 case "${label}" in
 	*docker*)

--- a/checks.sh
+++ b/checks.sh
@@ -19,7 +19,7 @@ optional_checks_to_perform='javahome mvn jdk'
 # Exceptions for trusted.ci.jenkins.io agents
 if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
 	case "${label}" in
-		docker)
+		docker|linux)
 			# Default JDK not as expected
             optional_checks_to_perform='javahome mvn';;
 		updatecenter)

--- a/checks.sh
+++ b/checks.sh
@@ -17,7 +17,7 @@ fi
 # Optional checks to perform, not run on every controller or label
 optional_checks_to_perform='javahome mvn jdk'
 # Exceptions for trusted.ci.jenkins.io agents
-if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io' ]]; then
+if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
 	case "${label}" in
 		docker)
 			# Default JDK not as expected

--- a/checks.sh
+++ b/checks.sh
@@ -28,7 +28,7 @@ if [[ "${JENKINS_URL}" == 'https://trusted.ci.jenkins.io/' ]]; then
 		docker|linux)
 			# Default JDK not as expected
             optional_checks_to_perform='javahome mvn docker';;
-		updatecenter)
+		updatecenter|agent-1)
 			# No JDK no mvn
             optional_checks_to_perform='';;
 	esac

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -23,7 +23,8 @@ def categorizedLabels = [:]
 
 // Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
 categorizedLabels['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21']
-categorizedLabels['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
+// TODO: confirm not used on trusted.ci (?)
+// categorizedLabels['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
 categorizedLabels['Linux processors'] = ['linux-amd64', 'linux-arm64']
 categorizedLabels['Docker platforms'] = ['docker', 'docker-windows', 'arm64docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
 categorizedLabels['Permanent agent'] = ['updatecenter']

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -1,145 +1,50 @@
-parallel "linux": {
-  stage('Test default "linux" agent label with tools') {
-    node('linux') {
-      sh 'java -version'
-      sh 'mvn -v'
-      
-      jdk21 = tool name: "jdk21", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk21}/bin", "JAVA_HOME=${jdk21}"]) {
-        sh 'mvn -v'
-      }
+//!/usr/bin/env groovy
 
-      jdk17 = tool name: "jdk17", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk17}/bin", "JAVA_HOME=${jdk17}"]) {
-        sh 'mvn -v'
-      }
+// Only one build running at a time, stop prior build if new build starts
+def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber) // Thanks to jglick
 
-      jdk11 = tool name: "jdk11", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk11}/bin", "JAVA_HOME=${jdk11}"]) {
-        sh 'mvn -v'
-      }
-    
-      jdk8 = tool name: "jdk8", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk8}/bin", "JAVA_HOME=${jdk8}"]) {
-          sh 'mvn -v'
-      }
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '15')),
+    disableResume(),
+    durabilityHint('PERFORMANCE_OPTIMIZED'),
+    pipelineTriggers([cron('H H/8 * * *')]), // Run once every 8 hours (three times a day)
+])
+
+// Define the sequential stages and the parallel steps inside each stage
+def sequentialStages = [:]
+// Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
+sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-21', 'maven-25', 'maven-8-windows', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows', 'maven-25-windows']
+sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
+sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
+sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker']
+sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
+
+// Generate a parallel step for each label in labels
+def generateParallelSteps(labels) {
+    def parallelNodes = [:]
+    for (unboundLabel in labels) {
+        def label = unboundLabel // Bind label before the closure
+        parallelNodes[label] = {
+            node(label) {
+                withEnv(["NODE_LABEL=${label}"]) {
+                    checkout scm
+                    if (isUnix()) {
+                        sh 'bash ./checks.sh "${NODE_LABEL}"'
+                    } else {
+                        pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
+                    }
+                }
+            }
+        }
     }
-  }
-},
-"ubuntu-22-amd64-maven-11": {
-  stage('Test specific "ubuntu-22-amd64-maven-11" agent label') {
-    node('ubuntu-22-amd64-maven-11') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
+    return parallelNodes
+}
+
+timeout(unit: 'MINUTES', time:29) {
+    for (unboundStage in sequentialStages) {
+        def boundStage = unboundStage // Bind label before the closure
+        stage(boundStage.key) {
+            parallel generateParallelSteps(sequentialStages[boundStage.key])
+        }
     }
-  }
-},
-"ubuntu-22-amd64-maven-17": {
-  stage('Test specific "ubuntu-22-amd64-maven-17" agent label') {
-    node('ubuntu-22-amd64-maven-17') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-    }
-  }
-},
-"ubuntu-22-amd64-maven-21": {
-  stage('Test specific "ubuntu-22-amd64-maven-21" agent label') {
-    node('ubuntu-22-amd64-maven-21') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-    }
-  }
-},
-"ubuntu-22-arm64-maven-21": {
-  stage('Test specific "ubuntu-22-arm64-maven-21" agent label') {
-    node('ubuntu-22-arm64-maven-21') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-    }
-  }
-},
-"win-2019-amd64-maven-11": {
-  stage('Test specific "win-2019-amd64-maven-11" agent label') {
-    node('win-2019-amd64-maven-11') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2019-amd64-maven-17": {
-  stage('Test specific "win-2019-amd64-maven-17" agent label') {
-    node('win-2019-amd64-maven-17') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2019-amd64-maven-21": {
-  stage('Test specific "win-2019-amd64-maven-21" agent label') {
-    node('win-2019-amd64-maven-21') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2022-amd64-maven-11": {
-  stage('Test specific "win-2022-amd64-maven-11" agent label') {
-    node('win-2022-amd64-maven-11') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2022-amd64-maven-17": {
-  stage('Test specific "win-2022-amd64-maven-17" agent label') {
-    node('win-2022-amd64-maven-17') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2022-amd64-maven-21": {
-  stage('Test specific "win-2022-amd64-maven-21" agent label') {
-    node('win-2022-amd64-maven-21') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2025-amd64-maven-25": {
-  stage('Test specific "win-2025-amd64-maven-25" agent label') {
-    node('win-2025-amd64-maven-25') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
 }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -12,15 +12,6 @@ properties([
 
 def categorizedLabels = [:]
 
-// TODO: remove afterward
-// Templates in ci.jenkins.io not in trusted.ci.jenkins.io:
-// - Maven and JDK: maven-8(-windows), maven-17-windows, maven-21-windows, maven-25(-windows)
-// - VM types: ubuntu-22-amd64-maven8, ubuntu-22-amd64-highmem-maven17
-// - Linux processors: s390x
-// - Docker platforms: s390xdocker
-// - Spot and OnDemand: all of them
-// Templates in ci.jenkins.io not in trusted.ci.jenkins.io (permanent agent): 'updatecenter'
-
 // Labels currently used on trusted.ci.jenkins.io (2026-02)
 // - core-taglibs-report-generator: docker&&linux
 // - crawler: maven-17

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -43,7 +43,8 @@ def generateParallelSteps(categorizedLabels) {
                             if (isUnix()) {
                                 sh 'bash ./checks.sh "${NODE_LABEL}"'
                             } else {
-                                pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
+                                pwsh 'env:'
+                                pwsh 'pwsh ./checks.ps1 -Label env:NODE_LABEL'
                             }
                         }
                     }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -43,8 +43,7 @@ def generateParallelSteps(categorizedLabels) {
                             if (isUnix()) {
                                 sh 'bash ./checks.sh "${NODE_LABEL}"'
                             } else {
-                                pwsh 'Get-ChildItem env:' || echo 'gci env failed'
-                                pwsh 'pwsh ./checks.ps1 -Label $env:NODE_LABEL' || echo 'failure'
+                                pwsh 'pwsh ./checks.ps1 -Label $env:NODE_LABEL'
                             }
                         }
                     }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -10,8 +10,7 @@ properties([
     pipelineTriggers([cron('H H/8 * * *')]), // Run once every 8 hours (three times a day)
 ])
 
-// Define the sequential stages and the parallel steps inside each stage
-def sequentialStages = [:]
+def categorizedLabels = [:]
 
 // TODO: remove afterward
 // Templates in ci.jenkins.io not in trusted.ci.jenkins.io:
@@ -23,25 +22,30 @@ def sequentialStages = [:]
 // Templates in ci.jenkins.io not in trusted.ci.jenkins.io (permanent agent): 'updatecenter', 'census'
 
 // Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
-sequentialStages['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21']
-sequentialStages['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
-sequentialStages['Linux processors'] = ['linux-amd64', 'linux-arm64']
-sequentialStages['Docker platforms'] = ['docker', 'docker-windows', 'arm64docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
-sequentialStages['Permanent agent'] = ['updatecenter', 'census']
+categorizedLabels['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21']
+categorizedLabels['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
+categorizedLabels['Linux processors'] = ['linux-amd64', 'linux-arm64']
+categorizedLabels['Docker platforms'] = ['docker', 'docker-windows', 'arm64docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
+categorizedLabels['Permanent agent'] = ['updatecenter', 'census']
 
-// Generate a parallel step for each label in labels
-def generateParallelSteps(labels) {
+// Generate a parallel step for each label
+def generateParallelSteps(categorizedLabels) {
     def parallelNodes = [:]
-    for (unboundLabel in labels) {
-        def label = unboundLabel // Bind label before the closure
-        parallelNodes[label] = {
-            node(label) {
-                withEnv(["NODE_LABEL=${label}"]) {
-                    checkout scm
-                    if (isUnix()) {
-                        sh 'bash ./checks.sh "${NODE_LABEL}"'
-                    } else {
-                        pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
+    categorizedLabels.each { categoryName, labels ->
+        labels.each { unboundLabel ->
+            def label = unboundLabel
+            def stageName = "${label} / ${categoryName}"
+            parallelNodes[stageName] = {
+                stage(stageName) {
+                    node(label) {
+                        withEnv(["NODE_LABEL=${label}"]) {
+                            checkout scm
+                            if (isUnix()) {
+                                sh 'bash ./checks.sh "${NODE_LABEL}"'
+                            } else {
+                                pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
+                            }
+                        }
                     }
                 }
             }
@@ -50,11 +54,6 @@ def generateParallelSteps(labels) {
     return parallelNodes
 }
 
-timeout(unit: 'MINUTES', time:29) {
-    for (unboundStage in sequentialStages) {
-        def boundStage = unboundStage // Bind label before the closure
-        stage(boundStage.key) {
-            parallel generateParallelSteps(sequentialStages[boundStage.key])
-        }
-    }
+timeout(unit: 'MINUTES', time: 29) {
+    parallel generateParallelSteps(categorizedLabels)
 }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -43,7 +43,7 @@ def generateParallelSteps(categorizedLabels) {
                             if (isUnix()) {
                                 sh 'bash ./checks.sh "${NODE_LABEL}"'
                             } else {
-                                pwsh 'pwsh ./checks.ps1 -Label $env:NODE_LABEL'
+                                pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
                             }
                         }
                     }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -21,13 +21,21 @@ def categorizedLabels = [:]
 // - Spot and OnDemand: all of them
 // Templates in ci.jenkins.io not in trusted.ci.jenkins.io (permanent agent): 'updatecenter'
 
-// Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
-categorizedLabels['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21']
-// TODO: confirm not used on trusted.ci (?)
-// categorizedLabels['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
-categorizedLabels['Linux processors'] = ['linux-amd64', 'linux-arm64']
-categorizedLabels['Docker platforms'] = ['docker', 'docker-windows', 'arm64docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
-categorizedLabels['Permanent agent'] = ['updatecenter']
+// Labels currently used on trusted.ci.jenkins.io (2026-02)
+// - core-taglibs-report-generator: docker&&linux
+// - crawler: maven-17
+// - javadoc: linux
+// - jenkins.io: docker&&linux, updatecenter
+// - purge-fastly-for-security-advisory: agent-1
+// - reindex_maven: linux
+// - repository-permissions-updater: maven-25
+// - update-center-sync-recent-releases: updatecenter
+// - update_center: updatecenter
+// - docker controller & agents: linux, windows-2019, windows-2022, windows-2025
+
+categorizedLabels['Maven and JDK'] = ['maven-17', 'maven-25']
+categorizedLabels['Docker platforms'] = ['docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
+categorizedLabels['Permanent agent'] = ['agent-1', 'updatecenter']
 
 // Generate a parallel step for each label
 def generateParallelSteps(categorizedLabels) {

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -19,14 +19,14 @@ def categorizedLabels = [:]
 // - Linux processors: s390x
 // - Docker platforms: s390xdocker
 // - Spot and OnDemand: all of them
-// Templates in ci.jenkins.io not in trusted.ci.jenkins.io (permanent agent): 'updatecenter', 'census'
+// Templates in ci.jenkins.io not in trusted.ci.jenkins.io (permanent agent): 'updatecenter'
 
 // Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
 categorizedLabels['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21']
 categorizedLabels['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
 categorizedLabels['Linux processors'] = ['linux-amd64', 'linux-arm64']
 categorizedLabels['Docker platforms'] = ['docker', 'docker-windows', 'arm64docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
-categorizedLabels['Permanent agent'] = ['updatecenter', 'census']
+categorizedLabels['Permanent agent'] = ['updatecenter']
 
 // Generate a parallel step for each label
 def generateParallelSteps(categorizedLabels) {

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -26,7 +26,7 @@ def categorizedLabels = [:]
 
 categorizedLabels['Maven and JDK'] = ['maven-17', 'maven-25']
 categorizedLabels['Docker platforms'] = ['docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
-categorizedLabels['Permanent agent'] = ['agent-1', 'updatecenter']
+categorizedLabels['Permanent agents'] = ['agent-1', 'updatecenter']
 
 // Generate a parallel step for each label
 def generateParallelSteps(categorizedLabels) {

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -43,8 +43,8 @@ def generateParallelSteps(categorizedLabels) {
                             if (isUnix()) {
                                 sh 'bash ./checks.sh "${NODE_LABEL}"'
                             } else {
-                                pwsh 'env:'
-                                pwsh 'pwsh ./checks.ps1 -Label env:NODE_LABEL'
+                                pwsh 'Get-ChildItem env:' || echo 'gci env failed'
+                                pwsh 'pwsh ./checks.ps1 -Label $env:NODE_LABEL' || echo 'failure'
                             }
                         }
                     }

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -13,11 +13,17 @@ properties([
 // Define the sequential stages and the parallel steps inside each stage
 def sequentialStages = [:]
 // Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
-sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-21', 'maven-25', 'maven-8-windows', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows', 'maven-25-windows']
-sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
-sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
-sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker']
-sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
+// Templates in ci.jenkins.io not in trusted.ci.jenkins.io:
+// - Maven and JDK: maven-8(-windows), maven-25(-windows)
+// - VM types: ubuntu-22-amd64-maven8, ubuntu-22-amd64-highmem-maven17
+// - Linux processors: s390x
+// - Docker platforms: s390xdocker
+// - Spot and OnDemand: docker-windows && nonspot, docker && nonspot, docker-highmem-nonspot
+sequentialStages['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows']
+sequentialStages['VM Types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
+sequentialStages['Linux Processors'] = ['linux-amd64', 'linux-arm64']
+sequentialStages['Docker Platforms'] = ['docker', 'docker-windows', 'arm64docker']
+sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker && spot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -12,18 +12,22 @@ properties([
 
 // Define the sequential stages and the parallel steps inside each stage
 def sequentialStages = [:]
-// Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
+
+// TODO: remove afterward
 // Templates in ci.jenkins.io not in trusted.ci.jenkins.io:
-// - Maven and JDK: maven-8(-windows), maven-25(-windows)
+// - Maven and JDK: maven-8(-windows), maven-17-windows, maven-21-windows, maven-25(-windows)
 // - VM types: ubuntu-22-amd64-maven8, ubuntu-22-amd64-highmem-maven17
 // - Linux processors: s390x
 // - Docker platforms: s390xdocker
-// - Spot and OnDemand: docker-windows && nonspot, docker && nonspot, docker-highmem-nonspot
-sequentialStages['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows']
-sequentialStages['VM Types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
-sequentialStages['Linux Processors'] = ['linux-amd64', 'linux-arm64']
-sequentialStages['Docker Platforms'] = ['docker', 'docker-windows', 'arm64docker']
-sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker && spot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
+// - Spot and OnDemand: all of them
+// Templates in ci.jenkins.io not in trusted.ci.jenkins.io (permanent agent): 'updatecenter', 'census'
+
+// Labels requested in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy and https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy
+sequentialStages['Maven and JDK'] = ['maven-11', 'maven-17', 'maven-21']
+sequentialStages['VM types'] = ['ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21']
+sequentialStages['Linux processors'] = ['linux-amd64', 'linux-arm64']
+sequentialStages['Docker platforms'] = ['docker', 'docker-windows', 'arm64docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
+sequentialStages['Permanent agent'] = ['updatecenter', 'census']
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {


### PR DESCRIPTION
This change uses the same pipeline as ci.jenkins.io (https://github.com/jenkins-infra/acceptance-tests/pull/49/commits/febcdf5c787ae3130cec7296ec0d0dc7cbea9410, modulo checked label lists), and adds a docker check to both scripts (Linux & Windows, https://github.com/jenkins-infra/acceptance-tests/pull/49/commits/fd51bda78319356fc8aafe5e6956b2de134fea71).

Labels specified in each job of trusted.ci.jenkins.io as of today (2026-02-06):
- core-taglibs-report-generator: docker&&linux
- crawler: maven-17
- javadoc: linux
- jenkins.io: docker&&linux, updatecenter
- purge-fastly-for-security-advisory: agent-1
- reindex_maven: linux
- repository-permissions-updater: maven-25
- update-center-sync-recent-releases: updatecenter
- update_center: updatecenter
- docker controller & agents: linux, windows-2019, windows-2022, windows-2025

Follow-up of:
- https://github.com/jenkins-infra/acceptance-tests/pull/48

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3800559559

#### Testing done

- https://ci.jenkins.io/job/Infra/job/acceptance-tests/view/change-requests/job/PR-49/
- Temporary job on trusted.ci.jenkins.io:
  - https://trusted.ci.jenkins.io/job/debug-acceptance-tests-lemeurherve/
  - commit: https://github.com/jenkins-infra/acceptance-tests/pull/49/commits/1b34a83ae0dc46b5d1fa2cf1364aad730e303f42
  - build logs: