### PR TITLE
feat(check-agent-availability): check `docker info` if label contains "docker"

### DIFF
--- a/checks.ps1
+++ b/checks.ps1
@@ -106,13 +106,7 @@ catch {
 }
 
 # Label-based JDK validation
-<<<<<<< HEAD
 if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
-||||||| parent of 85b1ae1 (don't check JDK version if label starts with 'windows')
-if ($Label -and $mavenPresent) {
-=======
-if (-not $Label.StartsWith('windows') -and $mavenPresent) {
->>>>>>> 85b1ae1 (don't check JDK version if label starts with 'windows')
     $jdk = $expectedDefaults.jdkVersion
 
     switch -Wildcard ($Label) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -197,27 +197,18 @@ if ($Label) {
 }
 
 # Docker check
-$dockerPresent = $false
-$mvnOutput = ''
-try {
-    $dockerInfo = (docker info) | Out-String
-    $dockerPresent = $true
-    Write-Host 'INFO: docker info below'
-    Write-Host $dockerInfo
-}
-catch {
-    Write-Host 'INFO: "docker info" command failed to execute, might not be present on this agent'
-    Write-Host $env:PATH
-    Get-Command docker -ErrorAction SilentlyContinue
-    $dockerInfo = (docker info) | Out-String
-}
 if ($Label -match 'docker') {
-    if ($dockerPresent) {
-        Write-Host ('INFO: docker is present as expected from "{0}" label' -f $Label)
-    }
-    else {
-        Write-Host ('ERROR: docker is not present as expected from "{0}" label, debugging informations below' -f $Label)
+    try {
+        $dockerInfo = (docker info) | Out-String
+        $dockerPresent = $true
+        Write-Host ('INFO: docker is present as expected from "{0}" label, info below' -f $Label)
         Write-Host $dockerInfo
+    }
+    catch {
+        Write-Host ('ERROR: docker is not present as expected from "{0}" label, debugging informations below' -f $Label)
+        Write-Host $env:PATH
+        Get-Command docker -ErrorAction SilentlyContinue
+        $dockerInfo = (docker info) | Out-String
         $failed += 1024
     }
 }

--- a/checks.ps1
+++ b/checks.ps1
@@ -200,10 +200,10 @@ if ($Label) {
 $dockerExpected = $false
 switch -Wildcard ($Label) {
     { $_ -like '*docker*' } {
-        $dockerExpected = $false
+        $dockerExpected = $true
     }
     { $_ -like 'windows*' } {
-        $dockerExpected = $false
+        $dockerExpected = $true
     }
     default {
         Write-Host ('INFO: docker is not expected from "{0}" label' -f $Label)

--- a/checks.ps1
+++ b/checks.ps1
@@ -106,7 +106,13 @@ catch {
 }
 
 # Label-based JDK validation
+<<<<<<< HEAD
 if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
+||||||| parent of 85b1ae1 (don't check JDK version if label starts with 'windows')
+if ($Label -and $mavenPresent) {
+=======
+if (-not $Label.StartsWith('windows') -and $mavenPresent) {
+>>>>>>> 85b1ae1 (don't check JDK version if label starts with 'windows')
     $jdk = $expectedDefaults.jdkVersion
 
     switch -Wildcard ($Label) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -197,10 +197,21 @@ if ($Label) {
 }
 
 # Docker check
-if ($Label -match 'docker') {
+$dockerExpected = $false
+switch -Wildcard ($Label) {
+    { $_ -like '*docker*' } {
+        $dockerExpected = $false
+    }
+    { $_ -like 'windows*' } {
+        $dockerExpected = $false
+    }
+    default {
+        Write-Host ('INFO: docker is not expected from "{0}" label' -f $Label)
+    }
+}
+if ($dockerExpected) {
     try {
         $dockerInfo = (docker info) | Out-String
-        $dockerPresent = $true
         Write-Host ('INFO: docker is present as expected from "{0}" label, info below' -f $Label)
         Write-Host $dockerInfo
     }

--- a/checks.ps1
+++ b/checks.ps1
@@ -206,12 +206,11 @@ try {
     Write-Host $dockerInfo
 }
 catch {
-    Write-Host 'ERROR: "docker info" command failed to execute. Debugging informations below:'
+    Write-Host 'INFO: "docker info" command failed to execute, might not be present on this agent. Debugging informations below:'
     Write-Host $env:PATH
     Get-Command docker -ErrorAction SilentlyContinue
     $dockerInfo = (docker info) | Out-String
     Write-Host $dockerInfo
-    $failed += 512
 }
 if ($dockerPresent -and $Label -match 'docker') {
     Write-Host ('INFO: docker is present as expected from "{0}" label' -f $Label)

--- a/checks.ps1
+++ b/checks.ps1
@@ -212,12 +212,14 @@ catch {
     $dockerInfo = (docker info) | Out-String
     Write-Host $dockerInfo
 }
-if ($dockerPresent -and $Label -match 'docker') {
-    Write-Host ('INFO: docker is present as expected from "{0}" label' -f $Label)
-}
-else {
-    Write-Host ('ERROR: docker is not present as expected from "{0}" label' -f $Label)
-    $failed += 1024
+if ($dockerPresent) {
+    if ($Label -match 'docker') {
+        Write-Host ('INFO: docker is present as expected from "{0}" label' -f $Label)
+    }
+    else {
+        Write-Host ('ERROR: docker is not present as expected from "{0}" label' -f $Label)
+        $failed += 1024
+    }
 }
 
 exit $failed

--- a/checks.ps1
+++ b/checks.ps1
@@ -196,4 +196,29 @@ if ($Label) {
     }
 }
 
+# Docker check
+$dockerPresent = $false
+$mvnOutput = ''
+try {
+    $dockerInfo = (docker info) | Out-String
+    $dockerPresent = $true
+    Write-Host 'INFO: docker info below'
+    Write-Host $dockerInfo
+}
+catch {
+    Write-Host 'ERROR: "docker info" command failed to execute. Debugging informations below:'
+    Write-Host $env:PATH
+    Get-Command docker -ErrorAction SilentlyContinue
+    $dockerInfo = (docker info) | Out-String
+    Write-Host $dockerInfo
+    $failed += 512
+}
+if ($dockerPresent -and $Label -match 'docker') {
+    Write-Host ('INFO: docker is present as expected from "{0}" label' -f $Label)
+}
+else {
+    Write-Host ('ERROR: docker is not present as expected from "{0}" label' -f $Label)
+    $failed += 1024
+}
+
 exit $failed

--- a/checks.ps1
+++ b/checks.ps1
@@ -206,18 +206,18 @@ try {
     Write-Host $dockerInfo
 }
 catch {
-    Write-Host 'INFO: "docker info" command failed to execute, might not be present on this agent. Debugging informations below:'
+    Write-Host 'INFO: "docker info" command failed to execute, might not be present on this agent'
     Write-Host $env:PATH
     Get-Command docker -ErrorAction SilentlyContinue
     $dockerInfo = (docker info) | Out-String
-    Write-Host $dockerInfo
 }
-if ($dockerPresent) {
-    if ($Label -match 'docker') {
+if ($Label -match 'docker') {
+    if ($dockerPresent) {
         Write-Host ('INFO: docker is present as expected from "{0}" label' -f $Label)
     }
     else {
-        Write-Host ('ERROR: docker is not present as expected from "{0}" label' -f $Label)
+        Write-Host ('ERROR: docker is not present as expected from "{0}" label, debugging informations below' -f $Label)
+        Write-Host $dockerInfo
         $failed += 1024
     }
 }

--- a/checks.sh
+++ b/checks.sh
@@ -71,11 +71,15 @@ mvn -v 2>/dev/null >/dev/null || {
 	exit 1;
 }
 
+label=''
+if [ $# -ge 1 ] && [ -n "$1" ]; then
+	label="$1"
+fi
 # This check relies on the java version output of the 'mvn -v' command
 # Java 8 needs to include '1.8' in the output
 # Java 11 needs to include '11.' in the output
 # Java 17 needs to include '17.' in the output
-if [ $# -ge 1 ] && [ -n "$1" ]; then
+if [ -n "${label}" ]; then
 	echo "label of the node: $1"
 
 	jdk="${DefaultJDKVersion}"
@@ -131,6 +135,24 @@ if [[ "$(mvn -v 2>&1)" != *"${DefaultMavenVersion}"* ]]; then
 	failed=$((failed + 128))
 else
 	echo "Maven version ${DefaultMavenVersion} OK for label '$1'"
+fi
+
+# Docker check
+docker_present=false
+docker info 2>/dev/null >/dev/null || {
+	set +e
+	echo "ERROR: command 'docker info' failed to execute. Debugging informations below:";
+	echo "${PATH}";
+	which docker;
+	docker info;
+	set -e
+	exit 1;
+}
+if [[ "${label}" == *docker* ]]; then
+    echo "INFO: docker is present as expected from \"${label}\" label"
+else
+    echo "ERROR: docker is not present as expected from \"${label}\" label"
+    failed=$((failed + 256))
 fi
 
 exit ${failed}

--- a/checks.sh
+++ b/checks.sh
@@ -138,15 +138,8 @@ else
 fi
 
 # Docker check
-docker_present=true
-docker info 2>/dev/null >/dev/null || {
-	echo "INFO: command 'docker info' failed to execute, might not be available on this agent."
-	docker_present=false
-}
 if [[ "${label}" == *docker* ]]; then
-	if [ $docker_present == "false" ]; then
-    	echo "INFO: docker is present as expected from \"${label}\" label"
-	else
+	docker info 2>/dev/null >/dev/null && echo "INFO: docker is present as expected from \"${label}\" label" || {
 		echo "ERROR: docker is not present as expected from \"${label}\" label, debugging informations below"
 		set +e
 		echo "${PATH}";
@@ -154,7 +147,7 @@ if [[ "${label}" == *docker* ]]; then
 		docker info;
 		set -e
 		failed=$((failed + 256))
-	fi
+	}
 fi
 
 exit ${failed}

--- a/checks.sh
+++ b/checks.sh
@@ -141,12 +141,11 @@ fi
 docker_present=false
 docker info 2>/dev/null >/dev/null || {
 	set +e
-	echo "ERROR: command 'docker info' failed to execute. Debugging informations below:";
+	echo "INFO: command 'docker info' failed to execute, might not be available on this agent. Debugging informations below:";
 	echo "${PATH}";
 	which docker;
 	docker info;
 	set -e
-	exit 1;
 }
 if [[ "${label}" == *docker* ]]; then
     echo "INFO: docker is present as expected from \"${label}\" label"

--- a/checks.sh
+++ b/checks.sh
@@ -142,7 +142,7 @@ docker_expected=false
 case "${label}" in
 	*docker*)
 		docker_expected=true;;
-	windows-*)
+	linux)
 		docker_expected=true;; # docker controller and agents
 	*)
 		echo "INFO: docker is not expected from '$1' label"

--- a/checks.sh
+++ b/checks.sh
@@ -138,7 +138,16 @@ else
 fi
 
 # Docker check
-if [[ "${label}" == *docker* ]]; then
+docker_expected=false
+case "${label}" in
+	*docker*)
+		docker_expected=true;;
+	windows-*)
+		docker_expected=true;; # docker controller and agents
+	*)
+		echo "INFO: docker is not expected from '$1' label"
+esac
+if [[ "${docker_expected}" == "true" ]]; then
 	docker info 2>/dev/null >/dev/null && echo "INFO: docker is present as expected from \"${label}\" label" || {
 		echo "ERROR: docker is not present as expected from \"${label}\" label, debugging informations below"
 		set +e

--- a/checks.sh
+++ b/checks.sh
@@ -138,20 +138,23 @@ else
 fi
 
 # Docker check
-docker_present=false
+docker_present=true
 docker info 2>/dev/null >/dev/null || {
-	set +e
-	echo "INFO: command 'docker info' failed to execute, might not be available on this agent. Debugging informations below:";
-	echo "${PATH}";
-	which docker;
-	docker info;
-	set -e
+	echo "INFO: command 'docker info' failed to execute, might not be available on this agent."
+	docker_present=false
 }
 if [[ "${label}" == *docker* ]]; then
-    echo "INFO: docker is present as expected from \"${label}\" label"
-else
-    echo "ERROR: docker is not present as expected from \"${label}\" label"
-    failed=$((failed + 256))
+	if [ $docker_present == "false" ]; then
+    	echo "INFO: docker is present as expected from \"${label}\" label"
+	else
+		echo "ERROR: docker is not present as expected from \"${label}\" label, debugging informations below"
+		set +e
+		echo "${PATH}";
+		which docker;
+		docker info;
+		set -e
+		failed=$((failed + 256))
+	fi
 fi
 
 exit ${failed}


### PR DESCRIPTION
This change adds a docker check if agent label contains "docker", to both scripts (Linux & Windows).

Extracted from:
- #49

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3800559559

#### Testing done

https://ci.jenkins.io/job/Infra/job/acceptance-tests/view/change-requests/job/PR-50

Last build full logs: [#30.txt](https://github.com/user-attachments/files/25009637/30.txt)
