### PR TITLE
chore: miscellaneous checks.ps1 fixes and missing ci.jenkins.io requested agent labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def sequentialStages = [:]
 sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-21', 'maven-25', 'maven-8-windows', 'maven-11-windows', 'maven-17-windows', 'maven-21-windows', 'maven-25-windows']
 sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
 sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
-sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker']
+sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker', 'windows-2019', 'windows-2022', 'windows-2025']
 sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
 
 // Generate a parallel step for each label in labels

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ sequentialStages['Maven and JDK'] = [ 'maven-8', 'maven-11', 'maven-17', 'maven-
 sequentialStages['VM Types'] = [ 'ubuntu-22-amd64-maven8', 'ubuntu-22-amd64-maven11', 'ubuntu-22-amd64-maven17', 'ubuntu-22-amd64-maven21', 'ubuntu-22-arm64-maven17', 'ubuntu-22-arm64-maven21', 'ubuntu-22-amd64-highmem-maven17']
 sequentialStages['Linux Processors'] = [ 's390x', 'linux-amd64', 'linux-arm64']
 sequentialStages['Docker Platforms'] = [ 's390xdocker', 'docker', 'docker-windows', 'arm64docker', 'windows-2019', 'windows-2022', 'windows-2025']
-sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
+sequentialStages['Spot and OnDemand'] = [ 'docker-windows && spot', 'docker-windows && nonspot', 'docker && spot', 'docker && nonspot', 'docker-highmem-nonspot', 'docker-highmem && spot', 'docker-highmem && nonspot'] // Pipeline Library (mostly), but also Docker-*agent and Jenkins ATH
 
 // Generate a parallel step for each label in labels
 def generateParallelSteps(labels) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -24,12 +24,12 @@ if ($env:JENKINS_ADVERTISED_HOSTNAME) {
 
 Write-Host "INFO: Label passed in parameter: $Label"
 Write-Host "INFO: expected default values below"
-$expectedDefaults | Out-String
+Write-Host ($expectedDefaults | Out-String)
 
 # System information
 $computerInfo = (Get-ComputerInfo)
 Write-Host "INFO: system information below"
-$computerInfo | Out-String
+Write-Host ($computerInfo | Out-String)
 try {
     Get-CimInstance Win32_Processor | Out-String
 }

--- a/checks.ps1
+++ b/checks.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 [CmdletBinding()]
 Param(
-    [Parameter(Position = 1)]
+    [Parameter(Position = 0)]
     [String] $Label
 )
 

--- a/checks.ps1
+++ b/checks.ps1
@@ -40,10 +40,10 @@ catch {
 # Default locale check
 $currentCulture = [System.Globalization.CultureInfo]::CurrentCulture.Name
 if ($currentCulture -eq $expectedDefaults.locale) {
-    Write-Host ('INFO: {0} locale is the expected one' -f $currentCulture)
+    Write-Host ('INFO: "{0}" is the expected locale' -f $currentCulture)
 }
 else {
-    Write-Host ('ERROR: {0} locale is not the expected one' -f $currentCulture, $expectedDefaults.locale)
+    Write-Host ('ERROR: "{0}" is not the expected "{1}" locale' -f $currentCulture, $expectedDefaults.locale)
     $failed += 1
 }
 

--- a/checks.ps1
+++ b/checks.ps1
@@ -104,7 +104,7 @@ catch {
 }
 
 # Label-based JDK validation
-if ($Label -and $mavenPresent) {
+if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
     $jdk = $expectedDefaults.jdkVersion
 
     switch -Wildcard ($Label) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -1,4 +1,6 @@
 #!/usr/bin/env pwsh
+# Note: this script is not compatible with PowerShell 5
+
 [CmdletBinding()]
 Param(
     [Parameter(Position = 0)]

--- a/checks.ps1
+++ b/checks.ps1
@@ -143,14 +143,17 @@ if ($Label -and -not $Label.StartsWith('windows') -and $mavenPresent) {
     }
 
     if ($jdkVersion) {
-        $javaLine = (mvn -v 2>&1) | Select-String 'Java version'
-        $jdkFromMaven = $javaLine.ToString().Split(' ')[2]
+        $jdkFromMaven = ''
+        $javaLine = (mvn -v 2>&1 | Select-String 'Java version').Line -replace ',', ''
+        if ($javaLine -match 'Java version:\s*([^\s,]+)') {
+            $jdkFromMaven = $Matches[1]
+        }
 
-        if ($jdkFromMaven -match [regex]::Escape($jdkVersion)) {
-            Write-Host ('INFO: JDK{0} from Maven matches the expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
+        if ($jdkFromMaven -and $jdkFromMaven -match [regex]::Escape($jdkVersion)) {
+            Write-Host ('INFO: Java version {0} from Maven matches expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
         }
         else {
-            Write-Host ('ERROR: JDK{0} from Maven does not match the expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
+            Write-Host ('ERROR: Java version {0} from Maven does not match expected JDK{1} from "{2}" label' -f $jdkFromMaven, $jdkVersion, $Label)
             $failed += 64
         }
     }


### PR DESCRIPTION
Amends:
- #48 

Extracted from:
- https://github.com/jenkins-infra/acceptance-tests/pull/50#issuecomment-3817147363

```
[2026-01-29T12:39:39.976Z] INFO: not enought permissions for calling 'Get-CimInstance Win32_Processor'
[2026-01-29T12:39:39.978Z] INFO: "en-US" is the expected locale
[2026-01-29T12:39:43.121Z] INFO: "jenkins" user exists
[2026-01-29T12:39:43.121Z] INFO: Running as "jenkins" user
[2026-01-29T12:39:43.121Z] INFO: Not running as Administrator as expected
[2026-01-29T12:39:43.122Z] INFO: JAVA_HOME environment variable is defined: C:/tools/jdk-21
[2026-01-29T12:39:52.854Z] INFO: Java version 21.0.9 from Maven matches expected JDK21 from "maven-21-windows" label
[2026-01-29T12:39:52.855Z] INFO: Maven output match the expected 3.9.12 version from "maven-21-windows" label:
[2026-01-29T12:39:52.856Z] Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
[2026-01-29T12:39:52.856Z] Maven home: C:\tools\apache-maven-3.9.12
[2026-01-29T12:39:52.856Z] Java version: 21.0.9, vendor: Eclipse Adoptium, runtime: C:\tools\jdk-21
[2026-01-29T12:39:52.856Z] Default locale: en_US, platform encoding: UTF-8
[2026-01-29T12:39:52.856Z] OS name: "windows server 2025", version: "10.0", arch: "amd64", family: "windows"
[2026-01-29T12:39:52.856Z] 
[2026-01-29T12:39:52.857Z] INFO: Windows 2025 version from Get-ComputerInfo matches default Windows 2025 version
```