### PR TITLE
fix(check-maven-cache): adjust min size after BlueOcean removal from bom

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ timeout(unit: 'MINUTES', time:5) {
     withEnv([
       'ARCHIVE_PATH=/cache/maven-bom-local-repo.tar.gz',
       'ARCHIVE_AGE_IN_DAYS=7',
-      'ARCHIVE_MIN_SIZE_IN_KB=1048576'
+      'ARCHIVE_MIN_SIZE_IN_KB=998000'
     ]) {
       stage('Check presence of the cache archive') {
         sh '''


### PR DESCRIPTION
Note: I did not find how the initial value was determined, so I've used a slightly lower value (998000Kb) than its current size (998804Kb).

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4877#issuecomment-3834837996