### PR TITLE
feat(acceptance-tests/cert.ci): pipeline and checks scripts from ci.jenkins.io

### DIFF
--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -10,17 +10,25 @@ properties([
 def categorizedLabels = [:]
 
 // Labels currently used on cert.ci.jenkins.io (2026-02-11, see https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3883361394)
+// - linux
+// - windows
+// - maven-17
+// - maven-21
+// - maven-25
+// - maven-17-windows
+// - maven-21-windows
+// - maven-25-windows
+
+// Used but not covered by current agent templates (?)
 // - linux-jdk-17
 // - linux-jdk-21
 // - linux-jdk-25
 // - windows-jdk-17
 // - windows-jdk-21
 // - windows-jdk-25
-// - linux
-// - windows
 
-
-categorizedLabels['Maven and JDK'] = ['linux-jdk-17', 'linux-jdk-21', 'linux-jdk-25', 'windows-jdk-17', 'windows-jdk-21', 'windows-jdk-25']
+categorizedLabels['Maven and JDK'] = ['maven-17', 'maven-21', 'maven-25', 'maven-17-windows', 'maven-21-windows', 'maven-25-windows']
+// categorizedLabels['Maven and JDK'] = ['linux-jdk-17', 'linux-jdk-21', 'linux-jdk-25', 'windows-jdk-17', 'windows-jdk-21', 'windows-jdk-25']
 categorizedLabels['Others'] = ['linux', 'windows']
 
 // Generate a parallel step for each label

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -1,149 +1,54 @@
-parallel "linux": {
-  stage('Test default "linux" agent label with tools') {
-    node('linux') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-      
-      /** TODO: uncomment when adding JDK25
-      String jdk25 = tool name: "jdk-25", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk25}/bin", "JAVA_HOME=${jdk25}"]) {
-        sh 'mvn -v'
-      }
-      **/
-      
-      String jdk21 = tool name: "jdk21", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk21}/bin", "JAVA_HOME=${jdk21}"]) {
-        sh 'mvn -v'
-      }
+//!/usr/bin/env groovy
 
-      String jdk17 = tool name: "jdk17", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk17}/bin", "JAVA_HOME=${jdk17}"]) {
-        sh 'mvn -v'
-      }
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '15')),
+    disableResume(),
+    durabilityHint('PERFORMANCE_OPTIMIZED'),
+    pipelineTriggers([cron('H H/8 * * *')]), // Run once every 8 hours (three times a day)
+])
 
-      String jdk11 = tool name: "jdk11", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk11}/bin", "JAVA_HOME=${jdk11}"]) {
-        sh 'mvn -v'
-      }
-    
-      String jdk8 = tool name: "jdk8", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk8}/bin", "JAVA_HOME=${jdk8}"]) {
-          sh 'mvn -v'
-      }
-    }
-  }
-},
-"windows": {
-  stage('Test default "windows" agent label with tools') {
-    node('windows') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
+def categorizedLabels = [:]
 
-      /** TODO: uncomment when adding JDK25
-      String jdk25 = tool name: "jdk-25", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk25}/bin", "JAVA_HOME=${jdk25}"]) {
-        bat 'mvn -v'
-      }
-      **/
-      
-      String jdk21 = tool name: "jdk21", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk21}/bin", "JAVA_HOME=${jdk21}"]) {
-        bat 'mvn -v'
-      }
+// Labels currently used on cert.ci.jenkins.io (2026-02-11, see https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3883361394)
+// - linux-jdk-17
+// - linux-jdk-21
+// - linux-jdk-25
+// - windows-jdk-17
+// - windows-jdk-21
+// - windows-jdk-25
+// - linux
+// - windows
 
-      String jdk17 = tool name: "jdk17", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk17}/bin", "JAVA_HOME=${jdk17}"]) {
-        bat 'mvn -v'
-      }
 
-      String jdk11 = tool name: "jdk11", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk11}/bin", "JAVA_HOME=${jdk11}"]) {
-        bat 'mvn -v'
-      }
-    
-      String jdk8 = tool name: "jdk8", type: 'jdk'
-      withEnv(["PATH+JDK=${jdk8}/bin", "JAVA_HOME=${jdk8}"]) {
-        bat 'mvn -v'
-      }
+categorizedLabels['Maven and JDK'] = ['linux-jdk-17', 'linux-jdk-21', 'linux-jdk-25', 'windows-jdk-17', 'windows-jdk-21', 'windows-jdk-25']
+categorizedLabels['Others'] = ['linux', 'windows']
+
+// Generate a parallel step for each label
+def generateParallelSteps(categorizedLabels) {
+    def parallelNodes = [:]
+    categorizedLabels.each { categoryName, labels ->
+        labels.each { unboundLabel ->
+            def label = unboundLabel
+            def stageName = "${label} / ${categoryName}"
+            parallelNodes[stageName] = {
+                stage(stageName) {
+                    node(label) {
+                        withEnv(["NODE_LABEL=${label}"]) {
+                            checkout scm
+                            if (isUnix()) {
+                                sh 'bash ./checks.sh "${NODE_LABEL}"'
+                            } else {
+                                pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
-},
-"ubuntu-22-amd64-maven-11": {
-  stage('Test specific "ubuntu-22-amd64-maven-11" agent label') {
-    node('ubuntu-22-amd64-maven-11') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-    }
-  }
-},
-"ubuntu-22-amd64-maven-17": {
-  stage('Test specific "ubuntu-22-amd64-maven-17" agent label') {
-    node('ubuntu-22-amd64-maven-17') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-    }
-  }
-},
-"ubuntu-22-amd64-maven-21": {
-  stage('Test specific "ubuntu-22-amd64-maven-21" agent label') {
-    node('ubuntu-22-amd64-maven-21') {
-      sh 'java -version'
-      sh 'mvn -v'
-      sh 'docker info'
-      sh 'cat /proc/cpuinfo'
-    }
-  }
-},
-"win-2019-amd64-maven-11": {
-  stage('Test specific "win-2019-amd64-maven-11" agent label') {
-    node('win-2019-amd64-maven-11') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2019-amd64-maven-17": {
-  stage('Test specific "win-2019-amd64-maven-17" agent label') {
-    node('win-2019-amd64-maven-17') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2019-amd64-maven-21": {
-  stage('Test specific "win-2019-amd64-maven-21" agent label') {
-    node('win-2019-amd64-maven-21') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
-},
-"win-2025-amd64-maven-25": {
-  stage('Test specific "win-2025-amd64-maven-25" agent label') {
-    node('win-2025-amd64-maven-25') {
-      bat 'java -version'
-      bat 'mvn -v'
-      bat 'docker info'
-      pwsh 'Get-CimInstance Win32_Processor | Out-String'
-      pwsh 'Get-ComputerInfo | Out-String'
-    }
-  }
+    return parallelNodes
+}
+
+timeout(unit: 'MINUTES', time: 29) {
+    parallel generateParallelSteps(categorizedLabels)
 }

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -12,6 +12,7 @@ def categorizedLabels = [:]
 // Labels currently used on cert.ci.jenkins.io (2026-02-11, see https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3883361394)
 // - linux
 // - windows
+// Labels made available by infra team
 // - maven-17
 // - maven-21
 // - maven-25
@@ -19,17 +20,8 @@ def categorizedLabels = [:]
 // - maven-21-windows
 // - maven-25-windows
 
-// Used but not covered by current agent templates (?)
-// - linux-jdk-17
-// - linux-jdk-21
-// - linux-jdk-25
-// - windows-jdk-17
-// - windows-jdk-21
-// - windows-jdk-25
-
+categorizedLabels['Main'] = ['linux', 'windows']
 categorizedLabels['Maven and JDK'] = ['maven-17', 'maven-21', 'maven-25', 'maven-17-windows', 'maven-21-windows', 'maven-25-windows']
-// categorizedLabels['Maven and JDK'] = ['linux-jdk-17', 'linux-jdk-21', 'linux-jdk-25', 'windows-jdk-17', 'windows-jdk-21', 'windows-jdk-25']
-categorizedLabels['Others'] = ['linux', 'windows']
 
 // Generate a parallel step for each label
 def generateParallelSteps(categorizedLabels) {

--- a/checks.ps1
+++ b/checks.ps1
@@ -51,6 +51,12 @@ if ($env:JENKINS_URL -eq 'https://trusted.ci.jenkins.io/') {
     }
 }
 
+# Exceptions for cert.ci.jenkins.io agents
+if ($env:JENKINS_URL -eq 'https://cert.ci.jenkins.io/') {
+    # Windows agents currently run as Administrator
+    $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Admin)
+}
+
 # Allow Mark Waite to run the same script on his home network
 if ($env:JENKINS_ADVERTISED_HOSTNAME) {
     $expectedDefaults.user = 'jagent'

--- a/checks.sh
+++ b/checks.sh
@@ -45,6 +45,16 @@ if [[ "${JENKINS_URL:-}" == 'https://trusted.ci.jenkins.io/' ]]; then
 	esac
 fi
 
+# Exceptions for cert.ci.jenkins.io agents
+if [[ "${JENKINS_URL:-}" == 'https://cert.ci.jenkins.io/' ]]; then
+	case "${label}" in
+		linux)
+			# Default JDK not as expected
+            optional_checks=$((optional_checks & ~CHECK_JDK));;
+		*)
+	esac
+fi
+
 has_check() {
     (( optional_checks & $1 ))
 }


### PR DESCRIPTION
Refs:
- https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3877195054
- https://github.com/jenkins-infra/helpdesk/issues/4955#issuecomment-3883361394

#### Testing done

Temporary test job on cert.ci.jenkins.io: https://cert.ci.jenkins.io/view/Top-Level%20Items/job/debug-acceptance-tests-lemeurherve/4 ✅ 

<details><summary>Build logs</summary>

```
[Skip to content](https://cert.ci.jenkins.io/view/Top-Level%20Items/job/debug-acceptance-tests-lemeurherve/4/console#skip2content)
[Jenkins](https://cert.ci.jenkins.io/)

    [Top-Level Items](https://cert.ci.jenkins.io/view/Top-Level%20Items/)
    [debug-acceptance-tests-lemeurherve](https://cert.ci.jenkins.io/view/Top-Level%20Items/job/debug-acceptance-tests-lemeurherve/)
    [#4](https://cert.ci.jenkins.io/view/Top-Level%20Items/job/debug-acceptance-tests-lemeurherve/4/)

Manage Jenkins
hlemeur
Status
Changes
Console Output
Edit Build Information
Thread Dump
Pause/resume
Replay
Pipeline Steps
Workspaces
Previous Build
Console
Download
View as plain text

Started by user[ hlemeur](https://cert.ci.jenkins.io/user/hlemeur)
Obtained cert.ci.jenkins.io/Jenkinsfile from git 
https://github.com/lemeurherve/acceptance-tests
Resume disabled by user, switching to high-performance, low-durability mode.
[Pipeline] Start of Pipeline
[Pipeline] properties
[Pipeline] timeout
Timeout set to expire in 29 min
[Pipeline] {
[Pipeline] parallel
[Pipeline] { (Branch: linux / Main)
[Pipeline] { (Branch: windows / Main)
[Pipeline] { (Branch: maven-17 / Maven and JDK)
[Pipeline] { (Branch: maven-21 / Maven and JDK)
[Pipeline] { (Branch: maven-25 / Maven and JDK)
[Pipeline] { (Branch: maven-17-windows / Maven and JDK)
[Pipeline] { (Branch: maven-21-windows / Maven and JDK)
[Pipeline] { (Branch: maven-25-windows / Maven and JDK)
[Pipeline] stage
[Pipeline] { (linux / Main)
[Pipeline] stage
[Pipeline] { (windows / Main)
[Pipeline] stage
[Pipeline] { (maven-17 / Maven and JDK)
[Pipeline] stage
[Pipeline] { (maven-21 / Maven and JDK)
[Pipeline] stage
[Pipeline] { (maven-25 / Maven and JDK)
[Pipeline] stage
[Pipeline] { (maven-17-windows / Maven and JDK)
[Pipeline] stage
[Pipeline] { (maven-21-windows / Maven and JDK)
[Pipeline] stage
[Pipeline] { (maven-25-windows / Maven and JDK)
[Pipeline] node
[Pipeline] node
[Pipeline] node
[Pipeline] node
[Pipeline] node
[Pipeline] node
[Pipeline] node
[Pipeline] node
Still waiting to schedule task
Waiting for next available executor on ‘ubuntu-22-amd64-maven-11-0c6cc0’
Still waiting to schedule task
Waiting for next available executor on ‘win-202-2334e0’
Still waiting to schedule task
All nodes of label ‘maven-17’ are offline
Still waiting to schedule task
All nodes of label ‘maven-21’ are offline
Still waiting to schedule task
All nodes of label ‘maven-25’ are offline
Still waiting to schedule task
All nodes of label ‘maven-17-windows’ are offline
Still waiting to schedule task
All nodes of label ‘maven-21-windows’ are offline
Still waiting to schedule task
Waiting for next available executor on ‘win-202-2334e0’
Running on ubuntu-22-amd64-maven-17-30dfd0 in /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
using credential github
Cloning the remote Git repository
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.52.0'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
Commit message: "cleanup"
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit} # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
 > git rev-list --no-walk 139111cf6881ec9890e34935c1e0045c970be603 # timeout=10
[Pipeline] isUnix
[Pipeline] sh
+ bash ./checks.sh maven-17
+ default_version_maven=3.9.12
+ default_version_jdk=jdk-21
+ default_locale=en_US.utf8
+ default_user=jenkins
+ label=
+ [[ 1 -ge 1 ]]
+ [[ -n maven-17 ]]
+ label=maven-17
+ echo 'INFO: label of the node: '\''maven-17'\'''
INFO: label of the node: 'maven-17'
+ CHECK_NONE=0
+ CHECK_JAVAHOME=1
+ CHECK_MAVEN=2
+ CHECK_JDK=4
+ CHECK_DOCKER=8
+ optional_checks=7
+ case "${label}" in
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\t\r\u\s\t\e\d\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\c\e\r\t\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ case "${label}" in
+ echo 'INFO: Optional checks bitmask: 7'
INFO: Optional checks bitmask: 7
+ [[ -v JENKINS_ADVERTISED_HOSTNAME ]]
+ failed=0
+ uname -a
Linux ubuntu-22-amd64-maven-17-30dfd0 6.8.0-1044-azure #50~22.04.1-Ubuntu SMP Wed Dec  3 15:13:22 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+ test -e /etc/os-release
+ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
+ test -e /proc/cpuinfo
+ cat /proc/cpuinfo
processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3240.295
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 1
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3244.012
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 1
initial apicid	: 1
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 2
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3241.601
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 2
initial apicid	: 2
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 3
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3245.301
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 3
initial apicid	: 3
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 4
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3240.808
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 4
initial apicid	: 4
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 5
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3291.048
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 5
initial apicid	: 5
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 6
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3244.474
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 6
initial apicid	: 6
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 7
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3243.127
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 7
initial apicid	: 7
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.86
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

+ test -e /proc/meminfo
+ cat /proc/meminfo
MemTotal:       32868196 kB
MemFree:        30848044 kB
MemAvailable:   31551100 kB
Buffers:           41648 kB
Cached:          1040856 kB
SwapCached:            0 kB
Active:          1152304 kB
Inactive:         562504 kB
Active(anon):     653672 kB
Inactive(anon):        0 kB
Active(file):     498632 kB
Inactive(file):   562504 kB
Unevictable:       30728 kB
Mlocked:           27656 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Zswap:                 0 kB
Zswapped:              0 kB
Dirty:               684 kB
Writeback:             0 kB
AnonPages:        660004 kB
Mapped:           277784 kB
Shmem:             12304 kB
KReclaimable:      31184 kB
Slab:             117220 kB
SReclaimable:      31184 kB
SUnreclaim:        86036 kB
KernelStack:        5056 kB
PageTables:         5540 kB
SecPageTables:         0 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:    16434096 kB
Committed_AS:    1823288 kB
VmallocTotal:   34359738367 kB
VmallocUsed:       36412 kB
VmallocChunk:          0 kB
Percpu:             4416 kB
HardwareCorrupted:     0 kB
AnonHugePages:    385024 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
Unaccepted:            0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:               0 kB
DirectMap4k:      128264 kB
DirectMap2M:     3016704 kB
DirectMap1G:    32505856 kB
++ locale -a
+ [[ C
C.utf8
en_US.utf8
POSIX =~ en_US.utf8 ]]
+ echo 'INFO: en_US.utf8 locale is available'
INFO: en_US.utf8 locale is available
+ getent passwd jenkins
+ echo 'INFO: '\''jenkins'\'' user exists'
INFO: 'jenkins' user exists
++ whoami
+ [[ jenkins != \j\e\n\k\i\n\s ]]
+ sudo -n whoami
sudo: a password is required
+ has_check CHECK_JAVAHOME
+ ((  optional_checks & CHECK_JAVAHOME  ))
+ set +u
+ [[ -z /opt/jdk-17 ]]
+ set -u
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 17.0.18, vendor: Eclipse Adoptium, runtime: /opt/jdk-17
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ -n Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 17.0.18, vendor: Eclipse Adoptium, runtime: /opt/jdk-17
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" ]]
+ echo 'INFO: command '\''mvn -v'\'' executed with success'
INFO: command 'mvn -v' executed with success
+ has_check CHECK_JDK
+ ((  optional_checks & CHECK_JDK  ))
+ [[ -n maven-17 ]]
+ jdk=jdk-21
+ case "${label}" in
+ jdk=jdk-17
+ case "${jdk}" in
+ expected_jdk=17.
++ mvn -v
++ grep 'Java version'
++ cut -d ' ' -f 3
+ jdk_from_maven=17.0.18,
+ [[ 17.0.18, != *\1\7\.* ]]
+ echo 'INFO: JDK Version ok 17.0.18, for maven-17'
INFO: JDK Version ok 17.0.18, for maven-17
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 17.0.18, vendor: Eclipse Adoptium, runtime: /opt/jdk-17
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 17.0.18, vendor: Eclipse Adoptium, runtime: /opt/jdk-17
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" != *\3\.\9\.\1\2* ]]
+ echo 'INFO: Maven version is matching the expected 3.9.12 version for label '\''maven-17'\'''
INFO: Maven version is matching the expected 3.9.12 version for label 'maven-17'
+ has_check CHECK_DOCKER
+ ((  optional_checks & CHECK_DOCKER  ))
+ echo 'WARNING: Docker check skipped'
WARNING: Docker check skipped
+ exit 0
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
Running on ubuntu-22-amd64-maven-25-97ffe0 in /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
using credential github
Cloning the remote Git repository
Running on ubuntu-22-amd64-maven-11-9f9030 in /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.52.0'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
using credential github
Cloning the remote Git repository
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.52.0'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] sh
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit} # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] sh
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit} # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
+ bash ./checks.sh maven-25
+ default_version_maven=3.9.12
+ default_version_jdk=jdk-21
+ default_locale=en_US.utf8
+ default_user=jenkins
+ label=
+ [[ 1 -ge 1 ]]
+ [[ -n maven-25 ]]
+ label=maven-25
+ echo 'INFO: label of the node: '\''maven-25'\'''
INFO: label of the node: 'maven-25'
+ CHECK_NONE=0
+ CHECK_JAVAHOME=1
+ CHECK_MAVEN=2
+ CHECK_JDK=4
+ CHECK_DOCKER=8
+ optional_checks=7
+ case "${label}" in
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\t\r\u\s\t\e\d\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\c\e\r\t\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ case "${label}" in
+ echo 'INFO: Optional checks bitmask: 7'
INFO: Optional checks bitmask: 7
+ [[ -v JENKINS_ADVERTISED_HOSTNAME ]]
+ failed=0
+ uname -a
Linux ubuntu-22-amd64-maven-25-97ffe0 6.8.0-1044-azure #50~22.04.1-Ubuntu SMP Wed Dec  3 15:13:22 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+ test -e /etc/os-release
+ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
+ test -e /proc/cpuinfo
+ cat /proc/cpuinfo
processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3227.753
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 1
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3242.736
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 1
initial apicid	: 1
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 2
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3242.095
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 2
initial apicid	: 2
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 3
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3243.308
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 3
initial apicid	: 3
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 4
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3244.121
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 4
initial apicid	: 4
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 5
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3244.425
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 5
initial apicid	: 5
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 6
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3239.651
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 6
initial apicid	: 6
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 7
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3243.563
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 7
initial apicid	: 7
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

+ test -e /proc/meminfo
+ cat /proc/meminfo
MemTotal:       32863968 kB
MemFree:        30832280 kB
MemAvailable:   31537980 kB
Buffers:           41708 kB
Cached:          1043400 kB
SwapCached:            0 kB
Active:          1163244 kB
Inactive:         566496 kB
Active(anon):     666016 kB
Inactive(anon):        0 kB
Active(file):     497228 kB
Inactive(file):   566496 kB
Unevictable:       30728 kB
Mlocked:           27656 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Zswap:                 0 kB
Zswapped:              0 kB
Dirty:               344 kB
Writeback:             0 kB
AnonPages:        661644 kB
Mapped:           277224 kB
Shmem:             12304 kB
KReclaimable:      31272 kB
Slab:             117636 kB
SReclaimable:      31272 kB
SUnreclaim:        86364 kB
KernelStack:        5180 kB
PageTables:         5568 kB
SecPageTables:         0 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:    16431984 kB
Committed_AS:    1821096 kB
VmallocTotal:   34359738367 kB
VmallocUsed:       36492 kB
VmallocChunk:          0 kB
Percpu:             4416 kB
HardwareCorrupted:     0 kB
AnonHugePages:    376832 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
Unaccepted:            0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:               0 kB
DirectMap4k:      142464 kB
DirectMap2M:     2998272 kB
DirectMap1G:    32505856 kB
++ locale -a
+ [[ C
C.utf8
en_US.utf8
POSIX =~ en_US.utf8 ]]
+ echo 'INFO: en_US.utf8 locale is available'
INFO: en_US.utf8 locale is available
+ getent passwd jenkins
+ echo 'INFO: '\''jenkins'\'' user exists'
INFO: 'jenkins' user exists
++ whoami
+ [[ jenkins != \j\e\n\k\i\n\s ]]
+ sudo -n whoami
sudo: a password is required
+ has_check CHECK_JAVAHOME
+ ((  optional_checks & CHECK_JAVAHOME  ))
+ set +u
+ [[ -z /opt/jdk-25 ]]
+ set -u
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ bash ./checks.sh linux
+ default_version_maven=3.9.12
+ default_version_jdk=jdk-21
+ default_locale=en_US.utf8
+ default_user=jenkins
+ label=
+ [[ 1 -ge 1 ]]
+ [[ -n linux ]]
+ label=linux
+ echo 'INFO: label of the node: '\''linux'\'''
INFO: label of the node: 'linux'
+ CHECK_NONE=0
+ CHECK_JAVAHOME=1
+ CHECK_MAVEN=2
+ CHECK_JDK=4
+ CHECK_DOCKER=8
+ optional_checks=7
+ case "${label}" in
+ optional_checks=15
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\t\r\u\s\t\e\d\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\c\e\r\t\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ case "${label}" in
+ optional_checks=11
+ echo 'INFO: Optional checks bitmask: 11'
INFO: Optional checks bitmask: 11
+ [[ -v JENKINS_ADVERTISED_HOSTNAME ]]
+ failed=0
+ uname -a
Linux ubuntu-22-amd64-maven-11-9f9030 6.8.0-1044-azure #50~22.04.1-Ubuntu SMP Wed Dec  3 15:13:22 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+ test -e /etc/os-release
+ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
+ test -e /proc/cpuinfo
+ cat /proc/cpuinfo
processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3245.316
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 1
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3238.430
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 1
initial apicid	: 1
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 2
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3245.218
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 2
initial apicid	: 2
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 3
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3244.093
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 3
initial apicid	: 3
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 4
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3245.282
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 4
initial apicid	: 4
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 5
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3244.397
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 5
initial apicid	: 5
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 6
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3237.621
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 6
initial apicid	: 6
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 7
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3240.310
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 7
initial apicid	: 7
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.85
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

+ test -e /proc/meminfo
+ cat /proc/meminfo
MemTotal:       32863964 kB
MemFree:        30817548 kB
MemAvailable:   31524368 kB
Buffers:           41576 kB
Cached:          1044728 kB
SwapCached:            0 kB
Active:          1163224 kB
Inactive:         566324 kB
Active(anon):     664644 kB
Inactive(anon):        0 kB
Active(file):     498580 kB
Inactive(file):   566324 kB
Unevictable:       30892 kB
Mlocked:           27820 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Zswap:                 0 kB
Zswapped:              0 kB
Dirty:               744 kB
Writeback:             0 kB
AnonPages:        663712 kB
Mapped:           276508 kB
Shmem:             12308 kB
KReclaimable:      31148 kB
Slab:             117228 kB
SReclaimable:      31148 kB
SUnreclaim:        86080 kB
KernelStack:        5088 kB
PageTables:         5644 kB
SecPageTables:         0 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:    16431980 kB
Committed_AS:    1828588 kB
VmallocTotal:   34359738367 kB
VmallocUsed:       36552 kB
VmallocChunk:          0 kB
Percpu:             4416 kB
HardwareCorrupted:     0 kB
AnonHugePages:    378880 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
Unaccepted:            0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:               0 kB
DirectMap4k:      136320 kB
DirectMap2M:     3004416 kB
DirectMap1G:    32505856 kB
++ locale -a
+ [[ C
C.utf8
en_US.utf8
POSIX =~ en_US.utf8 ]]
+ echo 'INFO: en_US.utf8 locale is available'
INFO: en_US.utf8 locale is available
+ getent passwd jenkins
+ echo 'INFO: '\''jenkins'\'' user exists'
INFO: 'jenkins' user exists
++ whoami
+ [[ jenkins != \j\e\n\k\i\n\s ]]
+ sudo -n whoami
sudo: a password is required
+ has_check CHECK_JAVAHOME
+ ((  optional_checks & CHECK_JAVAHOME  ))
+ set +u
+ [[ -z /opt/jdk-11 ]]
+ set -u
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 25.0.2, vendor: Eclipse Adoptium, runtime: /opt/jdk-25
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ -n Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 25.0.2, vendor: Eclipse Adoptium, runtime: /opt/jdk-25
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" ]]
+ echo 'INFO: command '\''mvn -v'\'' executed with success'
INFO: command 'mvn -v' executed with success
+ has_check CHECK_JDK
+ ((  optional_checks & CHECK_JDK  ))
+ [[ -n maven-25 ]]
+ jdk=jdk-21
+ case "${label}" in
+ jdk=jdk-25
+ case "${jdk}" in
+ expected_jdk=25
++ mvn -v
++ grep 'Java version'
++ cut -d ' ' -f 3
+ jdk_from_maven=25.0.2,
+ [[ 25.0.2, != *\2\5* ]]
+ echo 'INFO: JDK Version ok 25.0.2, for maven-25'
INFO: JDK Version ok 25.0.2, for maven-25
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 25.0.2, vendor: Eclipse Adoptium, runtime: /opt/jdk-25
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 25.0.2, vendor: Eclipse Adoptium, runtime: /opt/jdk-25
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" != *\3\.\9\.\1\2* ]]
+ echo 'INFO: Maven version is matching the expected 3.9.12 version for label '\''maven-25'\'''
INFO: Maven version is matching the expected 3.9.12 version for label 'maven-25'
+ has_check CHECK_DOCKER
+ ((  optional_checks & CHECK_DOCKER  ))
+ echo 'WARNING: Docker check skipped'
WARNING: Docker check skipped
+ exit 0
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 11.0.30, vendor: Eclipse Adoptium, runtime: /opt/jdk-11
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ -n Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 11.0.30, vendor: Eclipse Adoptium, runtime: /opt/jdk-11
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" ]]
+ echo 'INFO: command '\''mvn -v'\'' executed with success'
INFO: command 'mvn -v' executed with success
+ has_check CHECK_JDK
+ ((  optional_checks & CHECK_JDK  ))
+ echo 'WARNING: Expected JDK check skipped'
WARNING: Expected JDK check skipped
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 11.0.30, vendor: Eclipse Adoptium, runtime: /opt/jdk-11
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 11.0.30, vendor: Eclipse Adoptium, runtime: /opt/jdk-11
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" != *\3\.\9\.\1\2* ]]
+ echo 'INFO: Maven version is matching the expected 3.9.12 version for label '\''linux'\'''
INFO: Maven version is matching the expected 3.9.12 version for label 'linux'
+ has_check CHECK_DOCKER
+ ((  optional_checks & CHECK_DOCKER  ))
++ docker info
Running on ubuntu-22-amd64-maven-21-bd6f80 in /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
using credential github
Cloning the remote Git repository
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init /home/jenkins/agent/workspace/debug-acceptance-tests-lemeurherve # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.52.0'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
+ docker_info='Client: Docker Engine - Community
 Version:    28.5.2
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.31.1
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 1
 Server Version: 28.5.2
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: false
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: dea7da592f5d1d2b7755e3a161be07f43fad8f75
 runc version: v1.3.4-0-gd6d73eb8
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.8.0-1044-azure
 Operating System: Ubuntu 22.04.5 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 8
 Total Memory: 31.34GiB
 Name: ubuntu-22-amd64-maven-11-9f9030
 ID: ef1a3178-1c87-4712-b416-1fc608ba3848
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Registry Mirrors:
  https://dockerhubmirror.azurecr.io/
 Live Restore Enabled: false'
+ [[ -n Client: Docker Engine - Community
 Version:    28.5.2
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.31.1
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 1
 Server Version: 28.5.2
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: false
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: dea7da592f5d1d2b7755e3a161be07f43fad8f75
 runc version: v1.3.4-0-gd6d73eb8
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.8.0-1044-azure
 Operating System: Ubuntu 22.04.5 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 8
 Total Memory: 31.34GiB
 Name: ubuntu-22-amd64-maven-11-9f9030
 ID: ef1a3178-1c87-4712-b416-1fc608ba3848
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Registry Mirrors:
  https://dockerhubmirror.azurecr.io/
 Live Restore Enabled: false ]]
+ echo 'INFO: docker is present as expected from '\''linux'\'' label, see info below:'
INFO: docker is present as expected from 'linux' label, see info below:
+ echo 'Client: Docker Engine - Community
 Version:    28.5.2
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.31.1
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 1
 Server Version: 28.5.2
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: false
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: dea7da592f5d1d2b7755e3a161be07f43fad8f75
 runc version: v1.3.4-0-gd6d73eb8
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.8.0-1044-azure
 Operating System: Ubuntu 22.04.5 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 8
 Total Memory: 31.34GiB
 Name: ubuntu-22-amd64-maven-11-9f9030
 ID: ef1a3178-1c87-4712-b416-1fc608ba3848
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Registry Mirrors:
  https://dockerhubmirror.azurecr.io/
 Live Restore Enabled: false'
Client: Docker Engine - Community
 Version:    28.5.2
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.31.1
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 1
 Server Version: 28.5.2
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: false
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: dea7da592f5d1d2b7755e3a161be07f43fad8f75
 runc version: v1.3.4-0-gd6d73eb8
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.8.0-1044-azure
 Operating System: Ubuntu 22.04.5 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 8
 Total Memory: 31.34GiB
 Name: ubuntu-22-amd64-maven-11-9f9030
 ID: ef1a3178-1c87-4712-b416-1fc608ba3848
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Registry Mirrors:
  https://dockerhubmirror.azurecr.io/
 Live Restore Enabled: false
+ exit 0
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] sh
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit} # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
+ bash ./checks.sh maven-21
+ default_version_maven=3.9.12
+ default_version_jdk=jdk-21
+ default_locale=en_US.utf8
+ default_user=jenkins
+ label=
+ [[ 1 -ge 1 ]]
+ [[ -n maven-21 ]]
+ label=maven-21
+ echo 'INFO: label of the node: '\''maven-21'\'''
INFO: label of the node: 'maven-21'
+ CHECK_NONE=0
+ CHECK_JAVAHOME=1
+ CHECK_MAVEN=2
+ CHECK_JDK=4
+ CHECK_DOCKER=8
+ optional_checks=7
+ case "${label}" in
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\t\r\u\s\t\e\d\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ [[ https://cert.ci.jenkins.io/ == \h\t\t\p\s\:\/\/\c\e\r\t\.\c\i\.\j\e\n\k\i\n\s\.\i\o\/ ]]
+ case "${label}" in
+ echo 'INFO: Optional checks bitmask: 7'
INFO: Optional checks bitmask: 7
+ [[ -v JENKINS_ADVERTISED_HOSTNAME ]]
+ failed=0
+ uname -a
Linux ubuntu-22-amd64-maven-21-bd6f80 6.8.0-1044-azure #50~22.04.1-Ubuntu SMP Wed Dec  3 15:13:22 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
+ test -e /etc/os-release
+ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
+ test -e /proc/cpuinfo
+ cat /proc/cpuinfo
processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3240.254
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 1
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3240.168
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 0
cpu cores	: 4
apicid		: 1
initial apicid	: 1
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 2
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3238.744
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 2
initial apicid	: 2
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 3
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3240.021
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 1
cpu cores	: 4
apicid		: 3
initial apicid	: 3
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 4
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3256.048
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 4
initial apicid	: 4
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 5
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3241.115
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 2
cpu cores	: 4
apicid		: 5
initial apicid	: 5
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 6
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3245.534
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 6
initial apicid	: 6
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

processor	: 7
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 1
model name	: AMD EPYC 7763 64-Core Processor
stepping	: 1
microcode	: 0xffffffff
cpu MHz		: 3241.617
cache size	: 512 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 7
initial apicid	: 7
fpu		: yes
fpu_exception	: yes
cpuid level	: 13
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm
bugs		: sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
bogomips	: 4890.84
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management:

+ test -e /proc/meminfo
+ cat /proc/meminfo
MemTotal:       32863960 kB
MemFree:        30839912 kB
MemAvailable:   31543620 kB
Buffers:           41500 kB
Cached:          1041712 kB
SwapCached:            0 kB
Active:          1154628 kB
Inactive:         562412 kB
Active(anon):     655224 kB
Inactive(anon):        0 kB
Active(file):     499404 kB
Inactive(file):   562412 kB
Unevictable:       30728 kB
Mlocked:           27656 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Zswap:                 0 kB
Zswapped:              0 kB
Dirty:               756 kB
Writeback:             0 kB
AnonPages:        662644 kB
Mapped:           277608 kB
Shmem:             12304 kB
KReclaimable:      31100 kB
Slab:             117404 kB
SReclaimable:      31100 kB
SUnreclaim:        86304 kB
KernelStack:        5104 kB
PageTables:         5492 kB
SecPageTables:         0 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:    16431980 kB
Committed_AS:    1827368 kB
VmallocTotal:   34359738367 kB
VmallocUsed:       36460 kB
VmallocChunk:          0 kB
Percpu:             4416 kB
HardwareCorrupted:     0 kB
AnonHugePages:    376832 kB
ShmemHugePages:        0 kB
ShmemPmdMapped:        0 kB
FileHugePages:         0 kB
FilePmdMapped:         0 kB
Unaccepted:            0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:               0 kB
DirectMap4k:      126080 kB
DirectMap2M:     3014656 kB
DirectMap1G:    32505856 kB
++ locale -a
+ [[ C
C.utf8
en_US.utf8
POSIX =~ en_US.utf8 ]]
+ echo 'INFO: en_US.utf8 locale is available'
INFO: en_US.utf8 locale is available
+ getent passwd jenkins
+ echo 'INFO: '\''jenkins'\'' user exists'
INFO: 'jenkins' user exists
++ whoami
+ [[ jenkins != \j\e\n\k\i\n\s ]]
+ sudo -n whoami
sudo: a password is required
+ has_check CHECK_JAVAHOME
+ ((  optional_checks & CHECK_JAVAHOME  ))
+ set +u
+ [[ -z /opt/jdk-21 ]]
+ set -u
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 21.0.10, vendor: Eclipse Adoptium, runtime: /opt/jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ -n Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 21.0.10, vendor: Eclipse Adoptium, runtime: /opt/jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" ]]
+ echo 'INFO: command '\''mvn -v'\'' executed with success'
INFO: command 'mvn -v' executed with success
+ has_check CHECK_JDK
+ ((  optional_checks & CHECK_JDK  ))
+ [[ -n maven-21 ]]
+ jdk=jdk-21
+ case "${label}" in
+ jdk=jdk-21
+ case "${jdk}" in
+ expected_jdk=21
++ mvn -v
++ grep 'Java version'
++ cut -d ' ' -f 3
+ jdk_from_maven=21.0.10,
+ [[ 21.0.10, != *\2\1* ]]
+ echo 'INFO: JDK Version ok 21.0.10, for maven-21'
INFO: JDK Version ok 21.0.10, for maven-21
+ has_check CHECK_MAVEN
+ ((  optional_checks & CHECK_MAVEN  ))
++ mvn -v
+ maven_version='Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 21.0.10, vendor: Eclipse Adoptium, runtime: /opt/jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix"'
+ [[ Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: /usr/share/apache-maven-3.9.12
Java version: 21.0.10, vendor: Eclipse Adoptium, runtime: /opt/jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1044-azure", arch: "amd64", family: "unix" != *\3\.\9\.\1\2* ]]
+ echo 'INFO: Maven version is matching the expected 3.9.12 version for label '\''maven-21'\'''
INFO: Maven version is matching the expected 3.9.12 version for label 'maven-21'
+ has_check CHECK_DOCKER
+ ((  optional_checks & CHECK_DOCKER  ))
+ echo 'WARNING: Docker check skipped'
WARNING: Docker check skipped
+ exit 0
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
Running on win-202-bc0b40 in C:/Jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
Running on win-202-b618b0 in C:/Jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
using credential github
Cloning the remote Git repository
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init C:\Jenkins\agent\workspace\debug-acceptance-tests-lemeurherve # timeout=10
Running on win-202-b61870 in C:/Jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
using credential github
Cloning the remote Git repository
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init C:\Jenkins\agent\workspace\debug-acceptance-tests-lemeurherve # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.53.0.windows.1'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
using credential github
Cloning the remote Git repository
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init C:\Jenkins\agent\workspace\debug-acceptance-tests-lemeurherve # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.53.0.windows.1'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.53.0.windows.1'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
Running on win-202-9210d0 in C:/Jenkins/agent/workspace/debug-acceptance-tests-lemeurherve
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] checkout
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] pwsh
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse "refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit}" # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
using credential github
Cloning the remote Git repository
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] pwsh
Cloning repository https://github.com/lemeurherve/acceptance-tests
 > git init C:\Jenkins\agent\workspace\debug-acceptance-tests-lemeurherve # timeout=10
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse "refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit}" # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] pwsh
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse "refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit}" # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
 > git --version # timeout=10
 > git --version # 'git version 2.53.0.windows.1'
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
Checking out Revision 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e (refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline)
Commit message: "cleanup"
[Pipeline] isUnix
[Pipeline] pwsh
 > git config remote.origin.url https://github.com/lemeurherve/acceptance-tests # timeout=10
Fetching upstream changes from https://github.com/lemeurherve/acceptance-tests
using GIT_ASKPASS to set credentials GitHub credential for jenkinsci-cert-ci with 'repo' and 'workflow' scopes
 > git fetch --tags --force --progress -- https://github.com/lemeurherve/acceptance-tests +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse "refs/remotes/origin/helpesk4955-cert-ci-check-agent-availability-pipeline^{commit}" # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 31f5acd9d82a6c4cf17b2632f6f457dfb0413b7e # timeout=10
INFO: Label passed in parameter: maven-17-windows
INFO: expected default values below

Name                           Value
----                           -----
locale                         en-US
jdkVersion                     21
user                           jenkins
windowsVersion                 2025
mavenVersion                   3.9.12


INFO: Optional checks enabled: Jdk, Maven
INFO: Label passed in parameter: windows
INFO: expected default values below

Name                           Value
----                           -----
mavenVersion                   3.9.12
windowsVersion                 2025
locale                         en-US
jdkVersion                     21
user                           jenkins


INFO: Optional checks enabled: Jdk, Maven, Docker
INFO: Label passed in parameter: maven-25-windows
INFO: expected default values below

Name                           Value
----                           -----
windowsVersion                 2025
mavenVersion                   3.9.12
jdkVersion                     21
locale                         en-US
user                           jenkins


INFO: Optional checks enabled: Jdk, Maven
INFO: system information below

WindowsBuildLabEx                                       : 26100.32230.amd64fre.lt_release_svc_prod1.260110-0031
WindowsCurrentVersion                                   : 6.3
WindowsEditionId                                        : ServerDatacenter
WindowsInstallationType                                 : Server Core
WindowsInstallDateFromRegistry                          : 2/11/2026 12:09:10 PM
WindowsProductId                                        : 00491-50000-00001-AA703
WindowsProductName                                      : Windows Server 2025 Datacenter
WindowsRegisteredOrganization                           : 
WindowsRegisteredOwner                                  : 
WindowsSystemRoot                                       : C:\Windows
WindowsVersion                                          : 2009
WindowsUBR                                              : 32230
BiosCharacteristics                                     : {3, 9, 15, 16…}
BiosBIOSVersion                                         : {VRTUAL - 1, Hyper-V UEFI Release v4.1, Microsoft - 100032}
BiosBuildNumber                                         : 
BiosCaption                                             : Hyper-V UEFI Release v4.1
BiosCodeSet                                             : 
BiosCurrentLanguage                                     : 
BiosDescription                                         : Hyper-V UEFI Release v4.1
BiosEmbeddedControllerMajorVersion                      : 255
BiosEmbeddedControllerMinorVersion                      : 255
BiosFirmwareType                                        : Uefi
BiosIdentificationCode                                  : 
BiosInstallableLanguages                                : 
BiosInstallDate                                         : 
BiosLanguageEdition                                     : 
BiosListOfLanguages                                     : 
BiosManufacturer                                        : Microsoft Corporation
BiosName                                                : Hyper-V UEFI Release v4.1
BiosOtherTargetOS                                       : 
BiosPrimaryBIOS                                         : True
BiosReleaseDate                                         : 8/23/2024 12:00:00 AM
BiosSerialNumber                                        : 0000-0005-1319-3731-2324-0122-31
BiosSMBIOSBIOSVersion                                   : Hyper-V UEFI Release v4.1
BiosSMBIOSMajorVersion                                  : 3
BiosSMBIOSMinorVersion                                  : 1
BiosSMBIOSPresent                                       : True
BiosSoftwareElementState                                : Running
Bios[Status](https://cert.ci.jenkins.io/view/Top-Level%20Items/job/debug-acceptance-tests-lemeurherve/4/)                                              : OK
BiosSystemBiosMajorVersion                              : 4
BiosSystemBiosMinorVersion                              : 1
BiosTargetOperatingSystem                               : 0
BiosVersion                                             : VRTUAL - 1
CsAdminPasswordStatus                                   : Unknown
CsAutomaticManagedPagefile                              : False
CsAutomaticResetBootOption                              : True
CsAutomaticResetCapability                              : True
CsBootOptionOnLimit                                     : 
CsBootOptionOnWatchDog                                  : 
CsBootROMSupported                                      : True
CsBootStatus                                            : {0, 0, 0, 127…}
CsBootupState                                           : Normal boot
CsCaption                                               : win-202-bc0b40
CsChassisBootupState                                    : Safe
CsChassisSKUNumber                                      : Virtual Machine
CsCurrentTimeZone                                       : 0
CsDaylightInEffect                                      : 
CsDescription                                           : AT/AT COMPATIBLE
CsDNSHostName                                           : win-202-bc0b40
CsDomain                                                : WORKGROUP
CsDomainRole                                            : StandaloneServer
CsEnableDaylightSavingsTime                             : True
CsFrontPanelResetStatus                                 : Unknown
CsHypervisorPresent                                     : True
CsInfraredSupported                                     : False
CsInitialLoadInfo                                       : 
CsInstallDate                                           : 
CsKeyboardPasswordStatus                                : Unknown
CsLastLoadInfo                                          : 
CsManufacturer                                          : Microsoft Corporation
CsModel                                                 : Virtual Machine
CsName                                                  : win-202-bc0b40
CsNetworkAdapters                                       : {Ethernet 3}
CsNetworkServerModeEnabled                              : True
CsNumberOfLogicalProcessors                             : 8
CsNumberOfProcessors                                    : 1
CsProcessors                                            : {AMD EPYC 7763 64-Core Processor                }
CsOEMStringArray                                        : {[MS_VM_CERT/SHA1/9b80ca0d5dd061ec9da4e494f4c3fd1196270c22], 00000000000000000000000000000000, To be filled by OEM}
CsPartOfDomain                                          : False
CsPauseAfterReset                                       : -1
CsPCSystemType                                          : Desktop
CsPCSystemTypeEx                                        : Desktop
CsPowerManagementCapabilities                           : 
CsPowerManagementSupported                              : 
CsPowerOnPasswordStatus                                 : Unknown
CsPowerState                                            : Unknown
CsPowerSupplyState                                      : Safe
CsPrimaryOwnerContact                                   : 
CsPrimaryOwnerName                                      : 
CsResetCapability                                       : Other
CsResetCount                                            : -1
CsResetLimit                                            : -1
CsRoles                                                 : {LM_Workstation, LM_Server, NT, Server_NT}
CsStatus                                                : OK
CsSupportContactDescription                             : 
CsSystemFamily                                          : Virtual Machine
CsSystemSKUNumber                                       : None
CsSystemType                                            : x64-based PC
CsThermalState                                          : Safe
CsTotalPhysicalMemory                                   : 34358562816
CsPhysicallyInstalledMemory                             : 33554432
CsUserName                                              : 
CsWakeUpType                                            : PowerSwitch
CsWorkgroup                                             : WORKGROUP
OsName                                                  : Microsoft Windows Server 2025 Datacenter
OsType                                                  : WINNT
OsOperatingSystemSKU                                    : DatacenterServerEdition
OsVersion                                               : 10.0.26100
OsCSDVersion                                            : 
OsBuildNumber                                           : 26100
OsHotFixes                                              : {KB5066131, KB5073379, KB5072725, KB5071142}
OsBootDevice                                            : \Device\HarddiskVolume3
OsSystemDevice                                          : \Device\HarddiskVolume4
OsSystemDirectory                                       : C:\Windows\system32
OsSystemDrive                                           : C:
OsWindowsDirectory                                      : C:\Windows
OsCountryCode                                           : 1
OsCurrentTimeZone                                       : 0
OsLocaleID                                              : 0409
OsLocale                                                : en-US
OsLocalDateTime                                         : 2/11/2026 12:10:00 PM
OsLastBootUpTime                                        : 2/11/2026 12:08:40 PM
OsUptime                                                : 00:01:19.7181207
OsBuildType                                             : Multiprocessor Free
OsCodeSet                                               : 1252
OsDataExecutionPreventionAvailable                      : True
OsDataExecutionPrevention32BitApplications              : True
OsDataExecutionPreventionDrivers                        : True
OsDataExecutionPreventionSupportPolicy                  : OptOut
OsDebug                                                 : False
OsDistributed                                           : False
OsEncryptionLevel                                       : 256
OsForegroundApplicationBoost                            : Maximum
OsTotalVisibleMemorySize                                : 33553284
OsFreePhysicalMemory                                    : 31072784
OsTotalVirtualMemorySize                                : 38796164
OsFreeVirtualMemory                                     : 36232420
OsInUseVirtualMemory                                    : 2563744
OsTotalSwapSpaceSize                                    : 
OsSizeStoredInPagingFiles                               : 5242880
OsFreeSpaceInPagingFiles                                : 5242880
OsPagingFiles                                           : {C:\pagefile.sys}
OsHardwareAbstractionLayer                              : 10.0.26100.1
OsInstallDate                                           : 2/11/2026 12:09:10 PM
OsManufacturer                                          : Microsoft Corporation
OsMaxNumberOfProcesses                                  : 4294967295
OsMaxProcessMemorySize                                  : 137438953344
OsMuiLanguages                                          : {en-US}
OsNumberOfLicensedUsers                                 : 0
OsNumberOfProcesses                                     : 99
OsNumberOfUsers                                         : 3
OsOrganization                                          : 
OsArchitecture                                          : 64-bit
OsLanguage                                              : en-US
OsProductSuites                                         : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsOtherTypeDescription                                  : 
OsPAEEnabled                                            : 
OsPortableOperatingSystem                               : False
OsPrimary                                               : True
OsProductType                                           : Server
OsRegisteredUser                                        : 
OsSerialNumber                                          : 00491-50000-00001-AA703
OsServicePackMajorVersion                               : 0
OsServicePackMinorVersion                               : 0
OsStatus                                                : OK
OsSuites                                                : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsServerLevel                                           : ServerCore
KeyboardLayout                                          : en-US
TimeZone                                                : (UTC) Coordinated Universal Time
LogonServer                                             : 
PowerPlatformRole                                       : Desktop
HyperVisorPresent                                       : True
HyperVRequirementDataExecutionPreventionAvailable       : 
HyperVRequirementSecondLevelAddressTranslation          : 
HyperVRequirementVirtualizationFirmwareEnabled          : 
HyperVRequirementVMMonitorModeExtensions                : 
DeviceGuardSmartStatus                                  : Off
DeviceGuardRequiredSecurityProperties                   : 
DeviceGuardAvailableSecurityProperties                  : 
DeviceGuardSecurityServicesConfigured                   : 
DeviceGuardSecurityServicesRunning                      : 
DeviceGuardCodeIntegrityPolicyEnforcementStatus         : 
DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus : 


INFO: Label passed in parameter: maven-21-windows
INFO: expected default values below
INFO: system information below

WindowsBuildLabEx                                       : 26100.32230.amd64fre.lt_release_svc_prod1.260110-0031
WindowsCurrentVersion                                   : 6.3
WindowsEditionId                                        : ServerDatacenter
WindowsInstallationType                                 : Server Core
WindowsInstallDateFromRegistry                          : 2/11/2026 12:09:09 PM
WindowsProductId                                        : 00491-50000-00001-AA440
WindowsProductName                                      : Windows Server 2025 Datacenter
WindowsRegisteredOrganization                           : 
WindowsRegisteredOwner                                  : 
WindowsSystemRoot                                       : C:\Windows
WindowsVersion                                          : 2009
WindowsUBR                                              : 32230
BiosCharacteristics                                     : {3, 9, 15, 16…}
BiosBIOSVersion                                         : {VRTUAL - 1, Hyper-V UEFI Release v4.1, Microsoft - 100032}
BiosBuildNumber                                         : 
BiosCaption                                             : Hyper-V UEFI Release v4.1
BiosCodeSet                                             : 
BiosCurrentLanguage                                     : 
BiosDescription                                         : Hyper-V UEFI Release v4.1
BiosEmbeddedControllerMajorVersion                      : 255
BiosEmbeddedControllerMinorVersion                      : 255
BiosFirmwareType                                        : Uefi
BiosIdentificationCode                                  : 
BiosInstallableLanguages                                : 
BiosInstallDate                                         : 
BiosLanguageEdition                                     : 
BiosListOfLanguages                                     : 
BiosManufacturer                                        : Microsoft Corporation
BiosName                                                : Hyper-V UEFI Release v4.1
BiosOtherTargetOS                                       : 
BiosPrimaryBIOS                                         : True
BiosReleaseDate                                         : 6/10/2025 12:00:00 AM
BiosSerialNumber                                        : 0000-0007-0268-1096-0607-6590-91
BiosSMBIOSBIOSVersion                                   : Hyper-V UEFI Release v4.1
BiosSMBIOSMajorVersion                                  : 3
BiosSMBIOSMinorVersion                                  : 1
BiosSMBIOSPresent                                       : True
BiosSoftwareElementState                                : Running
BiosStatus                                              : OK
BiosSystemBiosMajorVersion                              : 4
BiosSystemBiosMinorVersion                              : 1
BiosTargetOperatingSystem                               : 0
BiosVersion                                             : VRTUAL - 1
CsAdminPasswordStatus                                   : Unknown
CsAutomaticManagedPagefile                              : False
CsAutomaticResetBootOption                              : True
CsAutomaticResetCapability                              : True
CsBootOptionOnLimit                                     : 
CsBootOptionOnWatchDog                                  : 
CsBootROMSupported                                      : True
CsBootStatus                                            : {0, 0, 0, 127…}
CsBootupState                                           : Normal boot
CsCaption                                               : win-202-b618b0
CsChassisBootupState                                    : Safe
CsChassisSKUNumber                                      : Virtual Machine
CsCurrentTimeZone                                       : 0
CsDaylightInEffect                                      : 
CsDescription                                           : AT/AT COMPATIBLE
CsDNSHostName                                           : win-202-b618b0
CsDomain                                                : WORKGROUP
CsDomainRole                                            : StandaloneServer
CsEnableDaylightSavingsTime                             : True
CsFrontPanelResetStatus                                 : Unknown
CsHypervisorPresent                                     : True
CsInfraredSupported                                     : False
CsInitialLoadInfo                                       : 
CsInstallDate                                           : 
CsKeyboardPasswordStatus                                : Unknown
CsLastLoadInfo                                          : 
CsManufacturer                                          : Microsoft Corporation
CsModel                                                 : Virtual Machine
CsName                                                  : win-202-b618b0
CsNetworkAdapters                                       : {Ethernet 3}
CsNetworkServerModeEnabled                              : True
CsNumberOfLogicalProcessors                             : 8
CsNumberOfProcessors                                    : 1
CsProcessors                                            : {AMD EPYC 7763 64-Core Processor                }
CsOEMStringArray                                        : {[MS_VM_CERT/SHA1/9b80ca0d5dd061ec9da4e494f4c3fd1196270c22], 00000000000000000000000000000000, To be filled by OEM}
CsPartOfDomain                                          : False
CsPauseAfterReset                                       : -1
CsPCSystemType                                          : Desktop
CsPCSystemTypeEx                                        : Desktop
CsPowerManagementCapabilities                           : 
CsPowerManagementSupported                              : 
CsPowerOnPasswordStatus                                 : Unknown
CsPowerState                                            : Unknown
CsPowerSupplyState                                      : Safe
CsPrimaryOwnerContact                                   : 
CsPrimaryOwnerName                                      : 
CsResetCapability                                       : Other
CsResetCount                                            : -1
CsResetLimit                                            : -1
CsRoles                                                 : {LM_Workstation, LM_Server, NT, Server_NT}
CsStatus                                                : OK
CsSupportContactDescription                             : 
CsSystemFamily                                          : Virtual Machine
CsSystemSKUNumber                                       : None
CsSystemType                                            : x64-based PC
CsThermalState                                          : Safe
CsTotalPhysicalMemory                                   : 34354229248
CsPhysicallyInstalledMemory                             : 33554432
CsUserName                                              : 
CsWakeUpType                                            : PowerSwitch
CsWorkgroup                                             : WORKGROUP
OsName                                                  : Microsoft Windows Server 2025 Datacenter
OsType                                                  : WINNT
OsOperatingSystemSKU                                    : DatacenterServerEdition
OsVersion                                               : 10.0.26100
OsCSDVersion                                            : 
OsBuildNumber                                           : 26100
OsHotFixes                                              : {KB5066131, KB5073379, KB5072725, KB5071142}
OsBootDevice                                            : \Device\HarddiskVolume3
OsSystemDevice                                          : \Device\HarddiskVolume4
OsSystemDirectory                                       : C:\Windows\system32
OsSystemDrive                                           : C:
OsWindowsDirectory                                      : C:\Windows
OsCountryCode                                           : 1
OsCurrentTimeZone                                       : 0
OsLocaleID                                              : 0409
OsLocale                                                : en-US
OsLocalDateTime                                         : 2/11/2026 12:10:01 PM
OsLastBootUpTime                                        : 2/11/2026 12:08:39 PM
OsUptime                                                : 00:01:21.3775381
OsBuildType                                             : Multiprocessor Free
OsCodeSet                                               : 1252
OsDataExecutionPreventionAvailable                      : True
OsDataExecutionPrevention32BitApplications              : True
OsDataExecutionPreventionDrivers                        : True
OsDataExecutionPreventionSupportPolicy                  : OptOut
OsDebug                                                 : False
OsDistributed                                           : False
OsEncryptionLevel                                       : 256
OsForegroundApplicationBoost                            : Maximum
OsTotalVisibleMemorySize                                : 33549052
OsFreePhysicalMemory                                    : 31040432
OsTotalVirtualMemorySize                                : 38791932
OsFreeVirtualMemory                                     : 36206260
OsInUseVirtualMemory                                    : 2585672
OsTotalSwapSpaceSize                                    : 
OsSizeStoredInPagingFiles                               : 5242880
OsFreeSpaceInPagingFiles                                : 5242880
OsPagingFiles                                           : {C:\pagefile.sys}
OsHardwareAbstractionLayer                              : 10.0.26100.1
OsInstallDate                                           : 2/11/2026 12:09:09 PM
OsManufacturer                                          : Microsoft Corporation
OsMaxNumberOfProcesses                                  : 4294967295
OsMaxProcessMemorySize                                  : 137438953344
OsMuiLanguages                                          : {en-US}
OsNumberOfLicensedUsers                                 : 0
OsNumberOfProcesses                                     : 99
OsNumberOfUsers                                         : 3
OsOrganization                                          : 
OsArchitecture                                          : 64-bit
OsLanguage                                              : en-US
OsProductSuites                                         : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsOtherTypeDescription                                  : 
OsPAEEnabled                                            : 
OsPortableOperatingSystem                               : False
OsPrimary                                               : True
OsProductType                                           : Server
OsRegisteredUser                                        : 
OsSerialNumber                                          : 00491-50000-00001-AA440
OsServicePackMajorVersion                               : 0
OsServicePackMinorVersion                               : 0
OsStatus                                                : OK
OsSuites                                                : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsServerLevel                                           : ServerCore
KeyboardLayout                                          : en-US
TimeZone                                                : (UTC) Coordinated Universal Time
LogonServer                                             : 
PowerPlatformRole                                       : Desktop
HyperVisorPresent                                       : True
HyperVRequirementDataExecutionPreventionAvailable       : 
HyperVRequirementSecondLevelAddressTranslation          : 
HyperVRequirementVirtualizationFirmwareEnabled          : 
HyperVRequirementVMMonitorModeExtensions                : 
DeviceGuardSmartStatus                                  : Off
DeviceGuardRequiredSecurityProperties                   : 
DeviceGuardAvailableSecurityProperties                  : 
DeviceGuardSecurityServicesConfigured                   : 
DeviceGuardSecurityServicesRunning                      : 
DeviceGuardCodeIntegrityPolicyEnforcementStatus         : 
DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus : 



Name                           Value
----                           -----
jdkVersion                     21
mavenVersion                   3.9.12
windowsVersion                 2025
locale                         en-US
user                           jenkins


INFO: Optional checks enabled: Jdk, Maven

DeviceID Name                                            Caption                            MaxClockSpeed SocketDesignat
                                                                                                          ion
-------- ----                                            -------                            ------------- --------------
CPU0     AMD EPYC 7763 64-Core Processor                 AMD64 Family 25 Model 1 Stepping 1 2445          None          


INFO: "en-US" is the expected locale
INFO: system information below

WindowsBuildLabEx                                       : 26100.32230.amd64fre.lt_release_svc_prod1.260110-0031
WindowsCurrentVersion                                   : 6.3
WindowsEditionId                                        : ServerDatacenter
WindowsInstallationType                                 : Server Core
WindowsInstallDateFromRegistry                          : 2/11/2026 12:09:08 PM
WindowsProductId                                        : 00491-50000-00001-AA955
WindowsProductName                                      : Windows Server 2025 Datacenter
WindowsRegisteredOrganization                           : 
WindowsRegisteredOwner                                  : 
WindowsSystemRoot                                       : C:\Windows
WindowsVersion                                          : 2009
WindowsUBR                                              : 32230
BiosCharacteristics                                     : {3, 9, 15, 16…}
BiosBIOSVersion                                         : {VRTUAL - 1, Hyper-V UEFI Release v4.1, Microsoft - 100032}
BiosBuildNumber                                         : 
BiosCaption                                             : Hyper-V UEFI Release v4.1
BiosCodeSet                                             : 
BiosCurrentLanguage                                     : 
BiosDescription                                         : Hyper-V UEFI Release v4.1
BiosEmbeddedControllerMajorVersion                      : 255
BiosEmbeddedControllerMinorVersion                      : 255
BiosFirmwareType                                        : Uefi
BiosIdentificationCode                                  : 
BiosInstallableLanguages                                : 
BiosInstallDate                                         : 
BiosLanguageEdition                                     : 
BiosListOfLanguages                                     : 
BiosManufacturer                                        : Microsoft Corporation
BiosName                                                : Hyper-V UEFI Release v4.1
BiosOtherTargetOS                                       : 
BiosPrimaryBIOS                                         : True
BiosReleaseDate                                         : 8/23/2024 12:00:00 AM
BiosSerialNumber                                        : 0000-0014-4826-2097-4023-5912-17
BiosSMBIOSBIOSVersion                                   : Hyper-V UEFI Release v4.1
BiosSMBIOSMajorVersion                                  : 3
BiosSMBIOSMinorVersion                                  : 1
BiosSMBIOSPresent                                       : True
BiosSoftwareElementState                                : Running
BiosStatus                                              : OK
BiosSystemBiosMajorVersion                              : 4
BiosSystemBiosMinorVersion                              : 1
BiosTargetOperatingSystem                               : 0
BiosVersion                                             : VRTUAL - 1
CsAdminPasswordStatus                                   : Unknown
CsAutomaticManagedPagefile                              : False
CsAutomaticResetBootOption                              : True
CsAutomaticResetCapability                              : True
CsBootOptionOnLimit                                     : 
CsBootOptionOnWatchDog                                  : 
CsBootROMSupported                                      : True
CsBootStatus                                            : {0, 0, 0, 127…}
CsBootupState                                           : Normal boot
CsCaption                                               : win-202-b61870
CsChassisBootupState                                    : Safe
CsChassisSKUNumber                                      : Virtual Machine
CsCurrentTimeZone                                       : 0
CsDaylightInEffect                                      : 
CsDescription                                           : AT/AT COMPATIBLE
CsDNSHostName                                           : win-202-b61870
CsDomain                                                : WORKGROUP
CsDomainRole                                            : StandaloneServer
CsEnableDaylightSavingsTime                             : True
CsFrontPanelResetStatus                                 : Unknown
CsHypervisorPresent                                     : True
CsInfraredSupported                                     : False
CsInitialLoadInfo                                       : 
CsInstallDate                                           : 
CsKeyboardPasswordStatus                                : Unknown
CsLastLoadInfo                                          : 
CsManufacturer                                          : Microsoft Corporation
CsModel                                                 : Virtual Machine
CsName                                                  : win-202-b61870
CsNetworkAdapters                                       : {Ethernet 3}
CsNetworkServerModeEnabled                              : True
CsNumberOfLogicalProcessors                             : 8
CsNumberOfProcessors                                    : 1
CsProcessors                                            : {AMD EPYC 7763 64-Core Processor                }
CsOEMStringArray                                        : {[MS_VM_CERT/SHA1/9b80ca0d5dd061ec9da4e494f4c3fd1196270c22], 00000000000000000000000000000000, To be filled by OEM}
CsPartOfDomain                                          : False
CsPauseAfterReset                                       : -1
CsPCSystemType                                          : Desktop
CsPCSystemTypeEx                                        : Desktop
CsPowerManagementCapabilities                           : 
CsPowerManagementSupported                              : 
CsPowerOnPasswordStatus                                 : Unknown
CsPowerState                                            : Unknown
CsPowerSupplyState                                      : Safe
CsPrimaryOwnerContact                                   : 
CsPrimaryOwnerName                                      : 
CsResetCapability                                       : Other
CsResetCount                                            : -1
CsResetLimit                                            : -1
CsRoles                                                 : {LM_Workstation, LM_Server, NT, Server_NT}
CsStatus                                                : OK
CsSupportContactDescription                             : 
CsSystemFamily                                          : Virtual Machine
CsSystemSKUNumber                                       : None
CsSystemType                                            : x64-based PC
CsThermalState                                          : Safe
CsTotalPhysicalMemory                                   : 34358562816
CsPhysicallyInstalledMemory                             : 33554432
CsUserName                                              : 
CsWakeUpType                                            : PowerSwitch
CsWorkgroup                                             : WORKGROUP
OsName                                                  : Microsoft Windows Server 2025 Datacenter
OsType                                                  : WINNT
OsOperatingSystemSKU                                    : DatacenterServerEdition
OsVersion                                               : 10.0.26100
OsCSDVersion                                            : 
OsBuildNumber                                           : 26100
OsHotFixes                                              : {KB5066131, KB5073379, KB5072725, KB5071142}
OsBootDevice                                            : \Device\HarddiskVolume3
OsSystemDevice                                          : \Device\HarddiskVolume4
OsSystemDirectory                                       : C:\Windows\system32
OsSystemDrive                                           : C:
OsWindowsDirectory                                      : C:\Windows
OsCountryCode                                           : 1
OsCurrentTimeZone                                       : 0
OsLocaleID                                              : 0409
OsLocale                                                : en-US
OsLocalDateTime                                         : 2/11/2026 12:10:01 PM
OsLastBootUpTime                                        : 2/11/2026 12:08:38 PM
OsUptime                                                : 00:01:23.2533527
OsBuildType                                             : Multiprocessor Free
OsCodeSet                                               : 1252
OsDataExecutionPreventionAvailable                      : True
OsDataExecutionPrevention32BitApplications              : True
OsDataExecutionPreventionDrivers                        : True
OsDataExecutionPreventionSupportPolicy                  : OptOut
OsDebug                                                 : False
OsDistributed                                           : False
OsEncryptionLevel                                       : 256
OsForegroundApplicationBoost                            : Maximum
OsTotalVisibleMemorySize                                : 33553284
OsFreePhysicalMemory                                    : 31058736
OsTotalVirtualMemorySize                                : 38796164
OsFreeVirtualMemory                                     : 36225360
OsInUseVirtualMemory                                    : 2570804
OsTotalSwapSpaceSize                                    : 
OsSizeStoredInPagingFiles                               : 5242880
OsFreeSpaceInPagingFiles                                : 5242880
OsPagingFiles                                           : {C:\pagefile.sys}
OsHardwareAbstractionLayer                              : 10.0.26100.1
OsInstallDate                                           : 2/11/2026 12:09:08 PM
OsManufacturer                                          : Microsoft Corporation
OsMaxNumberOfProcesses                                  : 4294967295
OsMaxProcessMemorySize                                  : 137438953344
OsMuiLanguages                                          : {en-US}
OsNumberOfLicensedUsers                                 : 0
OsNumberOfProcesses                                     : 99
OsNumberOfUsers                                         : 3
OsOrganization                                          : 
OsArchitecture                                          : 64-bit
OsLanguage                                              : en-US
OsProductSuites                                         : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsOtherTypeDescription                                  : 
OsPAEEnabled                                            : 
OsPortableOperatingSystem                               : False
OsPrimary                                               : True
OsProductType                                           : Server
OsRegisteredUser                                        : 
OsSerialNumber                                          : 00491-50000-00001-AA955
OsServicePackMajorVersion                               : 0
OsServicePackMinorVersion                               : 0
OsStatus                                                : OK
OsSuites                                                : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsServerLevel                                           : ServerCore
KeyboardLayout                                          : en-US
TimeZone                                                : (UTC) Coordinated Universal Time
LogonServer                                             : 
PowerPlatformRole                                       : Desktop
HyperVisorPresent                                       : True
HyperVRequirementDataExecutionPreventionAvailable       : 
HyperVRequirementSecondLevelAddressTranslation          : 
HyperVRequirementVirtualizationFirmwareEnabled          : 
HyperVRequirementVMMonitorModeExtensions                : 
DeviceGuardSmartStatus                                  : Off
DeviceGuardRequiredSecurityProperties                   : 
DeviceGuardAvailableSecurityProperties                  : 
DeviceGuardSecurityServicesConfigured                   : 
DeviceGuardSecurityServicesRunning                      : 
DeviceGuardCodeIntegrityPolicyEnforcementStatus         : 
DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus : 



DeviceID Name                                            Caption                            MaxClockSpeed SocketDesignat
                                                                                                          ion
-------- ----                                            -------                            ------------- --------------
CPU0     AMD EPYC 7763 64-Core Processor                 AMD64 Family 25 Model 1 Stepping 1 2445          None          


INFO: "en-US" is the expected locale

DeviceID Name                                            Caption                            MaxClockSpeed SocketDesignat
                                                                                                          ion
-------- ----                                            -------                            ------------- --------------
CPU0     AMD EPYC 7763 64-Core Processor                 AMD64 Family 25 Model 1 Stepping 1 2445          None          


INFO: "en-US" is the expected locale
INFO: "jenkins" user exists
INFO: Running as "jenkins" user
WARNING: Running as Administrator check skipped
INFO: JAVA_HOME environment variable is defined: C:/tools/jdk-17
INFO: system information below

WindowsBuildLabEx                                       : 26100.32230.amd64fre.lt_release_svc_prod1.260110-0031
WindowsCurrentVersion                                   : 6.3
WindowsEditionId                                        : ServerDatacenter
WindowsInstallationType                                 : Server Core
WindowsInstallDateFromRegistry                          : 2/11/2026 12:09:11 PM
WindowsProductId                                        : 00491-50000-00001-AA382
WindowsProductName                                      : Windows Server 2025 Datacenter
WindowsRegisteredOrganization                           : 
WindowsRegisteredOwner                                  : 
WindowsSystemRoot                                       : C:\Windows
WindowsVersion                                          : 2009
WindowsUBR                                              : 32230
BiosCharacteristics                                     : {3, 9, 15, 16…}
BiosBIOSVersion                                         : {VRTUAL - 1, Hyper-V UEFI Release v4.1, Microsoft - 100032}
BiosBuildNumber                                         : 
BiosCaption                                             : Hyper-V UEFI Release v4.1
BiosCodeSet                                             : 
BiosCurrentLanguage                                     : 
BiosDescription                                         : Hyper-V UEFI Release v4.1
BiosEmbeddedControllerMajorVersion                      : 255
BiosEmbeddedControllerMinorVersion                      : 255
BiosFirmwareType                                        : Uefi
BiosIdentificationCode                                  : 
BiosInstallableLanguages                                : 
BiosInstallDate                                         : 
BiosLanguageEdition                                     : 
BiosListOfLanguages                                     : 
BiosManufacturer                                        : Microsoft Corporation
BiosName                                                : Hyper-V UEFI Release v4.1
BiosOtherTargetOS                                       : 
BiosPrimaryBIOS                                         : True
BiosReleaseDate                                         : 3/8/2024 12:00:00 AM
BiosSerialNumber                                        : 0000-0004-2165-2544-7056-8052-94
BiosSMBIOSBIOSVersion                                   : Hyper-V UEFI Release v4.1
BiosSMBIOSMajorVersion                                  : 3
BiosSMBIOSMinorVersion                                  : 1
BiosSMBIOSPresent                                       : True
BiosSoftwareElementState                                : Running
BiosStatus                                              : OK
BiosSystemBiosMajorVersion                              : 4
BiosSystemBiosMinorVersion                              : 1
BiosTargetOperatingSystem                               : 0
BiosVersion                                             : VRTUAL - 1
CsAdminPasswordStatus                                   : Unknown
CsAutomaticManagedPagefile                              : False
CsAutomaticResetBootOption                              : True
CsAutomaticResetCapability                              : True
CsBootOptionOnLimit                                     : 
CsBootOptionOnWatchDog                                  : 
CsBootROMSupported                                      : True
CsBootStatus                                            : {0, 0, 0, 127…}
CsBootupState                                           : Normal boot
CsCaption                                               : win-202-9210d0
CsChassisBootupState                                    : Safe
CsChassisSKUNumber                                      : Virtual Machine
CsCurrentTimeZone                                       : 0
CsDaylightInEffect                                      : 
CsDescription                                           : AT/AT COMPATIBLE
CsDNSHostName                                           : win-202-9210d0
CsDomain                                                : WORKGROUP
CsDomainRole                                            : StandaloneServer
CsEnableDaylightSavingsTime                             : True
CsFrontPanelResetStatus                                 : Unknown
CsHypervisorPresent                                     : True
CsInfraredSupported                                     : False
CsInitialLoadInfo                                       : 
CsInstallDate                                           : 
CsKeyboardPasswordStatus                                : Unknown
CsLastLoadInfo                                          : 
CsManufacturer                                          : Microsoft Corporation
CsModel                                                 : Virtual Machine
CsName                                                  : win-202-9210d0
CsNetworkAdapters                                       : {Ethernet 3}
CsNetworkServerModeEnabled                              : True
CsNumberOfLogicalProcessors                             : 8
CsNumberOfProcessors                                    : 1
CsProcessors                                            : {AMD EPYC 7763 64-Core Processor                }
CsOEMStringArray                                        : {[MS_VM_CERT/SHA1/9b80ca0d5dd061ec9da4e494f4c3fd1196270c22], 00000000000000000000000000000000, To be filled by OEM}
CsPartOfDomain                                          : False
CsPauseAfterReset                                       : -1
CsPCSystemType                                          : Desktop
CsPCSystemTypeEx                                        : Desktop
CsPowerManagementCapabilities                           : 
CsPowerManagementSupported                              : 
CsPowerOnPasswordStatus                                 : Unknown
CsPowerState                                            : Unknown
CsPowerSupplyState                                      : Safe
CsPrimaryOwnerContact                                   : 
CsPrimaryOwnerName                                      : 
CsResetCapability                                       : Other
CsResetCount                                            : -1
CsResetLimit                                            : -1
CsRoles                                                 : {LM_Workstation, LM_Server, NT, Server_NT}
CsStatus                                                : OK
CsSupportContactDescription                             : 
CsSystemFamily                                          : Virtual Machine
CsSystemSKUNumber                                       : None
CsSystemType                                            : x64-based PC
CsThermalState                                          : Safe
CsTotalPhysicalMemory                                   : 34358562816
CsPhysicallyInstalledMemory                             : 33554432
CsUserName                                              : 
CsWakeUpType                                            : PowerSwitch
CsWorkgroup                                             : WORKGROUP
OsName                                                  : Microsoft Windows Server 2025 Datacenter
OsType                                                  : WINNT
OsOperatingSystemSKU                                    : DatacenterServerEdition
OsVersion                                               : 10.0.26100
OsCSDVersion                                            : 
OsBuildNumber                                           : 26100
OsHotFixes                                              : {KB5066131, KB5073379, KB5072725, KB5071142}
OsBootDevice                                            : \Device\HarddiskVolume3
OsSystemDevice                                          : \Device\HarddiskVolume4
OsSystemDirectory                                       : C:\Windows\system32
OsSystemDrive                                           : C:
OsWindowsDirectory                                      : C:\Windows
OsCountryCode                                           : 1
OsCurrentTimeZone                                       : 0
OsLocaleID                                              : 0409
OsLocale                                                : en-US
OsLocalDateTime                                         : 2/11/2026 12:10:04 PM
OsLastBootUpTime                                        : 2/11/2026 12:08:40 PM
OsUptime                                                : 00:01:23.7722809
OsBuildType                                             : Multiprocessor Free
OsCodeSet                                               : 1252
OsDataExecutionPreventionAvailable                      : True
OsDataExecutionPrevention32BitApplications              : True
OsDataExecutionPreventionDrivers                        : True
OsDataExecutionPreventionSupportPolicy                  : OptOut
OsDebug                                                 : False
OsDistributed                                           : False
OsEncryptionLevel                                       : 256
OsForegroundApplicationBoost                            : Maximum
OsTotalVisibleMemorySize                                : 33553284
OsFreePhysicalMemory                                    : 31057172
OsTotalVirtualMemorySize                                : 38796164
OsFreeVirtualMemory                                     : 36223988
OsInUseVirtualMemory                                    : 2572176
OsTotalSwapSpaceSize                                    : 
OsSizeStoredInPagingFiles                               : 5242880
OsFreeSpaceInPagingFiles                                : 5242880
OsPagingFiles                                           : {C:\pagefile.sys}
OsHardwareAbstractionLayer                              : 10.0.26100.1
OsInstallDate                                           : 2/11/2026 12:09:11 PM
OsManufacturer                                          : Microsoft Corporation
OsMaxNumberOfProcesses                                  : 4294967295
OsMaxProcessMemorySize                                  : 137438953344
OsMuiLanguages                                          : {en-US}
OsNumberOfLicensedUsers                                 : 0
OsNumberOfProcesses                                     : 99
OsNumberOfUsers                                         : 3
OsOrganization                                          : 
OsArchitecture                                          : 64-bit
OsLanguage                                              : en-US
OsProductSuites                                         : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsOtherTypeDescription                                  : 
OsPAEEnabled                                            : 
OsPortableOperatingSystem                               : False
OsPrimary                                               : True
OsProductType                                           : Server
OsRegisteredUser                                        : 
OsSerialNumber                                          : 00491-50000-00001-AA382
OsServicePackMajorVersion                               : 0
OsServicePackMinorVersion                               : 0
OsStatus                                                : OK
OsSuites                                                : {TerminalServices, DatacenterEdition, TerminalServicesSingleSession}
OsServerLevel                                           : ServerCore
KeyboardLayout                                          : en-US
TimeZone                                                : (UTC) Coordinated Universal Time
LogonServer                                             : 
PowerPlatformRole                                       : Desktop
HyperVisorPresent                                       : True
HyperVRequirementDataExecutionPreventionAvailable       : 
HyperVRequirementSecondLevelAddressTranslation          : 
HyperVRequirementVirtualizationFirmwareEnabled          : 
HyperVRequirementVMMonitorModeExtensions                : 
DeviceGuardSmartStatus                                  : Off
DeviceGuardRequiredSecurityProperties                   : 
DeviceGuardAvailableSecurityProperties                  : 
DeviceGuardSecurityServicesConfigured                   : 
DeviceGuardSecurityServicesRunning                      : 
DeviceGuardCodeIntegrityPolicyEnforcementStatus         : 
DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus : 


INFO: "jenkins" user exists
INFO: Running as "jenkins" user
WARNING: Running as Administrator check skipped
INFO: JAVA_HOME environment variable is defined: C:/tools/jdk-25
INFO: "jenkins" user exists
INFO: Running as "jenkins" user
WARNING: Running as Administrator check skipped
INFO: JAVA_HOME environment variable is defined: C:/tools/jdk-25

DeviceID Name                                            Caption                            MaxClockSpeed SocketDesignat
                                                                                                          ion
-------- ----                                            -------                            ------------- --------------
CPU0     AMD EPYC 7763 64-Core Processor                 AMD64 Family 25 Model 1 Stepping 1 2445          None          


INFO: "en-US" is the expected locale
INFO: "jenkins" user exists
INFO: Running as "jenkins" user
WARNING: Running as Administrator check skipped
INFO: JAVA_HOME environment variable is defined: C:/tools/jdk-21
INFO: Java version 17.0.18 from Maven matches expected JDK17 from "[maven-17](https://cert.ci.jenkins.io/label/maven-17/)-windows" label
INFO: Maven output match the expected 3.9.12 version from "maven-17-windows" label:
Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: C:\tools\apache-maven-3.9.12
Java version: 17.0.18, vendor: Eclipse Adoptium, runtime: C:\tools\jdk-17
Default locale: en_US, platform encoding: Cp1252
OS name: "windows server 2025", version: "10.0", arch: "amd64", family: "windows"

INFO: Windows 2025 version from Get-ComputerInfo matches default Windows 2025 version
WARNING: Docker check skipped
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
INFO: Java version 25.0.2 from Maven matches expected JDK25 from "maven-25-windows" label
INFO: Maven output match the expected 3.9.12 version from "maven-25-windows" label:
Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: C:\tools\apache-maven-3.9.12
Java version: 25.0.2, vendor: Eclipse Adoptium, runtime: C:\tools\jdk-25
Default locale: en_US, platform encoding: UTF-8
OS name: "windows server 2025", version: "10.0", arch: "amd64", family: "windows"

INFO: Windows 2025 version from Get-ComputerInfo matches default Windows 2025 version
WARNING: Docker check skipped
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
INFO: Maven output match the expected 3.9.12 version from "windows" label:
Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: C:\tools\apache-maven-3.9.12
Java version: 25.0.2, vendor: Eclipse Adoptium, runtime: C:\tools\jdk-25
Default locale: en_US, platform encoding: UTF-8
OS name: "windows server 2025", version: "10.0", arch: "amd64", family: "windows"

INFO: Windows 2025 version from Get-ComputerInfo matches default Windows 2025 version
INFO: Java version 21.0.10 from Maven matches expected JDK21 from "[maven-21](https://cert.ci.jenkins.io/label/maven-21/)-windows" label
INFO: Maven output match the expected 3.9.12 version from "maven-21-windows" label:
Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1)
Maven home: C:\tools\apache-maven-3.9.12
Java version: 21.0.10, vendor: Eclipse Adoptium, runtime: C:\tools\jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "windows server 2025", version: "10.0", arch: "amd64", family: "windows"

INFO: Windows 2025 version from Get-ComputerInfo matches default Windows 2025 version
WARNING: Docker check skipped
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
INFO: docker is present as expected from "windows" label, info below
Client:
 Version:    28.5.2
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.14.1
    Path:     C:\ProgramData\Docker\cli-plugins\docker-buildx.exe

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 0
 Server Version: 28.5.2
 Storage Driver: windowsfilter
  Windows: 
 Logging Driver: json-file
 Plugins:
  Volume: local
  Network: ics internal l2bridge l2tunnel nat null overlay private transparent
  Log: awslogs etwlogs fluentd gcplogs gelf json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Default Isolation: process
 Kernel Version: 10.0 26100 (26100.32230.amd64fre.lt_release_svc_prod1.260110-0031)
 Operating System: Microsoft Windows Server Version 24H2 (OS Build 26100.32230)
 OSType: windows
 Architecture: x86_64
 CPUs: 8
 Total Memory: 31.99GiB
 Name: win-202-b618b0
 ID: 2cc7c1bf-c972-4cbd-8b9d-6562524ff8ae
 Docker Root Dir: C:\ProgramData\docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  ::1/128
  127.0.0.0/8
 Live Restore Enabled: false
 Product License: Community Engine


[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // parallel
[Pipeline] }
[Pipeline] // timeout
[Pipeline] End of Pipeline
Finished: SUCCESS
```

</details>