### PR TITLE
feat: update `check-agent-availability` to maven 3.9.13

### DIFF
--- a/checks.ps1
+++ b/checks.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version Latest
 $failed = 0
 $expectedDefaults = @{
     locale         = 'en-US'
-    mavenVersion   = '3.9.12'
+    mavenVersion   = '3.9.13'
     jdkVersion     = 21
     windowsVersion = 2025
     user           = 'jenkins'

--- a/checks.sh
+++ b/checks.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 
 # A pull request can be used as validation for ci.jenkins.io when changing an agent template characteristics
 # See process following TDD principle mentioned at https://github.com/jenkins-infra/helpdesk/issues/4949#issuecomment-3755425511
-default_version_maven="3.9.12"
+default_version_maven="3.9.13"
 default_version_jdk="jdk-21"
 default_locale="en_US.utf8"
 default_user="jenkins"


### PR DESCRIPTION
This change updates default Maven version to 3.9.13 in the agents check.

https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/PR-58

Merging this PR should be the last task of https://github.com/jenkins-infra/helpdesk/issues/5031.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5031