### PR TITLE
feat(check-agent-availability): add infra.ci.jenkins.io

### DIFF
--- a/checks.ps1
+++ b/checks.ps1
@@ -133,12 +133,14 @@ if ($optionalChecks.HasFlag([OptionalCheck]::Admin)) {
 }
 
 # JAVA_HOME check
-if (-not $env:JAVA_HOME) {
-    Write-Host 'ERROR: JAVA_HOME environment variable is undefined'
-    $failed += 16
-}
-else {
-    Write-Host ('INFO: JAVA_HOME environment variable is defined: {0}' -f $env:JAVA_HOME)
+if ($optionalChecks.HasFlag([OptionalCheck]::Jdk)) {
+    if (-not $env:JAVA_HOME) {
+        Write-Host 'ERROR: JAVA_HOME environment variable is undefined'
+        $failed += 16
+    }
+    else {
+        Write-Host ('INFO: JAVA_HOME environment variable is defined: {0}' -f $env:JAVA_HOME)
+    }
 }
 
 # Maven CLI check

--- a/checks.ps1
+++ b/checks.ps1
@@ -57,6 +57,15 @@ if ($env:JENKINS_URL -eq 'https://cert.ci.jenkins.io/') {
     $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Admin)
 }
 
+# Exceptions for infra.ci.jenkins.io agents
+if ($env:JENKINS_URL -eq 'https://infra.ci.jenkins.io/') {
+    # Windows agents currently run as Administrator
+    $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Admin)
+    # Windows agents are not building or running any java code
+    $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Jdk)
+    $optionalChecks = $optionalChecks -band (-bnot [OptionalCheck]::Maven)
+}
+
 # Allow Mark Waite to run the same script on his home network
 if ($env:JENKINS_ADVERTISED_HOSTNAME) {
     $expectedDefaults.user = 'jagent'

--- a/checks.sh
+++ b/checks.sh
@@ -59,11 +59,8 @@ fi
 if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
 	case "${label}" in
 		linux*|jnlp*)
-			# Default JDK not as expected
+			# Agents are not building or running any java code
             optional_checks=$((optional_checks & ~CHECK_JDK));;
-		windows*)
-			# No JAVA_HOME defined
-            optional_checks=$((optional_checks & ~CHECK_JAVAHOME));;
 		*)
 	esac
 fi

--- a/checks.sh
+++ b/checks.sh
@@ -55,6 +55,19 @@ if [[ "${JENKINS_URL:-}" == 'https://cert.ci.jenkins.io/' ]]; then
 	esac
 fi
 
+# Exceptions for infra.ci.jenkins.io agents
+if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
+	case "${label}" in
+		linux)
+			# Default JDK not as expected
+            optional_checks=$((optional_checks & ~CHECK_JDK));;
+		windows*)
+			# No JAVA_HOME defined
+            optional_checks=$((optional_checks & ~CHECK_JAVAHOME));;
+		*)
+	esac
+fi
+
 has_check() {
     (( optional_checks & $1 ))
 }

--- a/checks.sh
+++ b/checks.sh
@@ -55,16 +55,6 @@ if [[ "${JENKINS_URL:-}" == 'https://cert.ci.jenkins.io/' ]]; then
 	esac
 fi
 
-# Exceptions for infra.ci.jenkins.io agents
-if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
-	case "${label}" in
-		linux*|jnlp*)
-			# Agents are not building or running any java code
-            optional_checks=$((optional_checks & ~CHECK_JDK));;
-		*)
-	esac
-fi
-
 has_check() {
     (( optional_checks & $1 ))
 }

--- a/checks.sh
+++ b/checks.sh
@@ -58,11 +58,9 @@ fi
 # Exceptions for infra.ci.jenkins.io agents
 if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
 	case "${label}" in
-		linux)
-			# "linux" Kubernetes agents don't have docker
-            optional_checks=$((optional_checks & ~CHECK_DOCKER));;
-		jnlp*)
-			# Kubernetes agents are set to JDK25 by default
+		linux|jnlp*)
+			# Kubernetes agents don't have docker and are set to JDK25 by default
+            optional_checks=$((optional_checks & ~CHECK_DOCKER))
             optional_checks=$((optional_checks & ~CHECK_JDK));;
 		*)
 	esac

--- a/checks.sh
+++ b/checks.sh
@@ -58,7 +58,7 @@ fi
 # Exceptions for infra.ci.jenkins.io agents
 if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
 	case "${label}" in
-		linux)
+		linux*|jnlp*)
 			# Default JDK not as expected
             optional_checks=$((optional_checks & ~CHECK_JDK));;
 		windows*)

--- a/checks.sh
+++ b/checks.sh
@@ -58,6 +58,9 @@ fi
 # Exceptions for infra.ci.jenkins.io agents
 if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
 	case "${label}" in
+		linux-amd64*|linux-arm64*)
+			# Ephemeral agents have docker
+            optional_checks=$((optional_checks | CHECK_DOCKER));;
 		linux|jnlp*)
 			# Kubernetes agents don't have docker and are set to JDK25 by default
             optional_checks=$((optional_checks & ~CHECK_DOCKER))

--- a/checks.sh
+++ b/checks.sh
@@ -55,6 +55,19 @@ if [[ "${JENKINS_URL:-}" == 'https://cert.ci.jenkins.io/' ]]; then
 	esac
 fi
 
+# Exceptions for infra.ci.jenkins.io agents
+if [[ "${JENKINS_URL:-}" == 'https://infra.ci.jenkins.io/' ]]; then
+	case "${label}" in
+		linux)
+			# "linux" Kubernetes agents don't have docker
+            optional_checks=$((optional_checks & ~CHECK_DOCKER));;
+		jnlp*)
+			# Kubernetes agents are set to JDK25 by default
+            optional_checks=$((optional_checks & ~CHECK_JDK));;
+		*)
+	esac
+fi
+
 has_check() {
     (( optional_checks & $1 ))
 }

--- a/infra.ci.jenkins.io/Jenkinsfile
+++ b/infra.ci.jenkins.io/Jenkinsfile
@@ -1,0 +1,43 @@
+//!/usr/bin/env groovy
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '15')),
+    disableResume(),
+    durabilityHint('PERFORMANCE_OPTIMIZED'),
+    pipelineTriggers([cron('H H/8 * * *')]), // Run once every 8 hours (three times a day)
+])
+
+def categorizedLabels = [:]
+
+categorizedLabels['ephemeral-agents'] = ['linux-amd64', 'linux-arm64', 'linux-amd64-nonspot', 'linux-arm64-nonspot', 'windows-2019', 'windows-2025']
+categorizedLabels['kubernetes-agents'] = ['linux', 'jnlp-linux-amd64', 'jnlp-linux-arm64']
+
+// Generate a parallel step for each label
+def generateParallelSteps(categorizedLabels) {
+    def parallelNodes = [:]
+    categorizedLabels.each { categoryName, labels ->
+        labels.each { unboundLabel ->
+            def label = unboundLabel
+            def stageName = "${label} / ${categoryName}"
+            parallelNodes[stageName] = {
+                stage(stageName) {
+                    node(label) {
+                        withEnv(["NODE_LABEL=${label}"]) {
+                            checkout scm
+                            if (isUnix()) {
+                                sh 'bash ./checks.sh "${NODE_LABEL}"'
+                            } else {
+                                pwsh 'pwsh ./checks.ps1 -Label "${env:NODE_LABEL}"'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return parallelNodes
+}
+
+timeout(unit: 'MINUTES', time: 29) {
+    parallel generateParallelSteps(categorizedLabels)
+}

--- a/infra.ci.jenkins.io/Jenkinsfile
+++ b/infra.ci.jenkins.io/Jenkinsfile
@@ -9,7 +9,7 @@ properties([
 
 def categorizedLabels = [:]
 
-categorizedLabels['ephemeral-agents'] = ['linux-amd64', 'linux-arm64', 'linux-amd64-nonspot', 'linux-arm64-nonspot', 'windows-2019', 'windows-2025']
+categorizedLabels['ephemeral-agents'] = ['linux-amd64', 'linux-arm64', 'linux-arm64-nonspot', 'windows-2019', 'windows-2025']
 categorizedLabels['kubernetes-agents'] = ['linux', 'jnlp-linux-amd64', 'jnlp-linux-arm64']
 
 // Generate a parallel step for each label

--- a/infra.ci.jenkins.io/README.adoc
+++ b/infra.ci.jenkins.io/README.adoc
@@ -1,0 +1,4 @@
+= Pipeline Job used by the Infra Team to validate agent allocation on infra.ci.jenkins.io
+
+This test allocates each of the agent types and performs a trivial step on the agent.
+Timeout fails the job if it does not complete within half an hour.


### PR DESCRIPTION
This change adds a pipeline for infra.ci.jenkins.io to facilitate validations for https://github.com/jenkins-infra/helpdesk/issues/5043 and https://github.com/jenkins-infra/helpdesk/issues/5042

#### Testing done

Temporary job created manually: https://infra.ci.jenkins.io/job/check-agent-availability/6