### PR TITLE
feat(check-agent-availability): add build status report publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,3 +47,5 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
+
+publishBuildStatusReport()

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -52,3 +52,5 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
+
+publishBuildStatusReport()

--- a/infra.ci.jenkins.io/Jenkinsfile
+++ b/infra.ci.jenkins.io/Jenkinsfile
@@ -41,3 +41,5 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
+
+publishBuildStatusReport()

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -57,3 +57,5 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
+
+publishBuildStatusReport()


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds publishBuildStatusReport() after the parallel agent checks so build staleness is tracked via Datadog monitors.
