### PR TITLE
fix(Jenkinsfile): wrap publishBuildStatusReport around node block for controller jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,3 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
-
-node('linux-arm64') {
-    publishBuildStatusReport()
-}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,4 +48,6 @@ timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
 
-publishBuildStatusReport()
+node('linux-arm64') {
+    publishBuildStatusReport()
+}

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -52,7 +52,3 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
-
-node('linux') {
-    publishBuildStatusReport()
-}

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -53,4 +53,6 @@ timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
 
-publishBuildStatusReport()
+node('linux') {
+    publishBuildStatusReport()
+}

--- a/infra.ci.jenkins.io/Jenkinsfile
+++ b/infra.ci.jenkins.io/Jenkinsfile
@@ -42,4 +42,6 @@ timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
 
-publishBuildStatusReport()
+node('jnlp-linux-arm64') {
+    publishBuildStatusReport()
+}

--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -58,4 +58,6 @@ timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
 
-publishBuildStatusReport()
+node('linux') {
+    publishBuildStatusReport()
+}


### PR DESCRIPTION

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

Fixes `MissingContextVariableException` after merging #60. `publishBuildStatusReport()` requires a `FilePath` context (`pwd`/`writeFile`/`sh`) which is only available inside a `node` block.

delaying integrating publishBuildStatusReport in cert.ci.jenkins.io (no global pipeline library defined on that controller) and ci.jenkins.io jobs (missing write credentials) until fixed. 

**Failing build:** https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/check-agent-availability/6154/console
