### PR TITLE
feat(Jenkinsfile/cert.ci): load pipeline library

### DIFF
--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -60,3 +60,7 @@ def generateParallelSteps(categorizedLabels) {
 timeout(unit: 'MINUTES', time: 29) {
     parallel generateParallelSteps(categorizedLabels)
 }
+
+node('linux') {
+    publishBuildStatusReport()
+}

--- a/cert.ci.jenkins.io/Jenkinsfile
+++ b/cert.ci.jenkins.io/Jenkinsfile
@@ -1,5 +1,13 @@
 //!/usr/bin/env groovy
 
+library(
+  identifier: 'pipeline-library@master',
+  retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/jenkins-infra/pipeline-library.git',
+  ])
+)
+
 properties([
     buildDiscarder(logRotator(numToKeepStr: '15')),
     disableResume(),


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/2843

This PR loads the pipeline library in the jenkinsfile to include `publishBuildStatusReport` step