### PR TITLE
chore(trusted.ci) remove obsolete references to `agent-2`

### DIFF
--- a/trusted.ci.jenkins.io/Jenkinsfile
+++ b/trusted.ci.jenkins.io/Jenkinsfile
@@ -17,7 +17,7 @@ def categorizedLabels = [:]
 // - crawler: maven-17
 // - javadoc: linux
 // - jenkins.io: docker&&linux, updatecenter
-// - purge-fastly-for-security-advisory: agent-1
+// - purge-fastly-for-security-advisory: updatecenter
 // - reindex_maven: linux
 // - repository-permissions-updater: maven-25
 // - update-center-sync-recent-releases: updatecenter
@@ -26,7 +26,7 @@ def categorizedLabels = [:]
 
 categorizedLabels['Maven and JDK'] = ['maven-17', 'maven-25']
 categorizedLabels['Docker platforms'] = ['docker', 'linux', 'windows-2019', 'windows-2022', 'windows-2025']
-categorizedLabels['Permanent agents'] = ['agent-1', 'agent-2', 'updatecenter']
+categorizedLabels['Permanent agents'] = ['agent-2', 'updatecenter']
 
 // Generate a parallel step for each label
 def generateParallelSteps(categorizedLabels) {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5067#issuecomment-4307752144

The job configuration for `purge-fastly-for-security-advisory` was updated to use a label instead of a direct agent reference prior to the migration from `agent-1` to `agent-2`:

<img width="1395" height="325" alt="Capture d’écran 2026-04-24 à 14 39 12" src="https://github.com/user-attachments/assets/026f7c3f-25ef-4606-bdbf-19472c4a46a2" />
