### PR TITLE
feat: update check-agent-availability to maven `3.9.15`

### DIFF
--- a/checks.ps1
+++ b/checks.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version Latest
 $failed = 0
 $expectedDefaults = @{
     locale         = 'en-US'
-    mavenVersion   = '3.9.13'
+    mavenVersion   = '3.9.15'
     jdkVersion     = 21
     windowsVersion = 2025
     user           = 'jenkins'

--- a/checks.sh
+++ b/checks.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 
 # A pull request can be used as validation for ci.jenkins.io when changing an agent template characteristics
 # See process following TDD principle mentioned at https://github.com/jenkins-infra/helpdesk/issues/4949#issuecomment-3755425511
-default_version_maven="3.9.13"
+default_version_maven="3.9.15"
 default_version_jdk="jdk-21"
 default_locale="en_US.utf8"
 default_user="jenkins"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5078