### PR TITLE
feat(check-agent-availability/infra.ci): add `kubectl` checks

### DIFF
--- a/infra.ci.jenkins.io/Jenkinsfile
+++ b/infra.ci.jenkins.io/Jenkinsfile
@@ -39,7 +39,8 @@ def generateParallelSteps(categorizedLabels, clusters) {
     }
     clusters.each { clusterName -> 
         parallelNodes[clusterName] = {
-            stage(clusterName) {
+            def stageName = "${clusterName} access"
+            stage(stageName) {
                 node('jnlp-linux-arm64') {
                     withCredentials([file(credentialsId: "kubeconfig-${clusterName}", variable: 'KUBECONFIG')]) {
                         sh 'kubectl cluster-info'

--- a/infra.ci.jenkins.io/Jenkinsfile
+++ b/infra.ci.jenkins.io/Jenkinsfile
@@ -12,8 +12,10 @@ def categorizedLabels = [:]
 categorizedLabels['ephemeral-agents'] = ['linux-amd64', 'linux-arm64', 'linux-arm64-nonspot']
 categorizedLabels['kubernetes-agents'] = ['linux', 'jnlp-linux-amd64', 'jnlp-linux-arm64']
 
+def clusters = ['publick8s', 'privatek8s', 'privatek8s-sponsored', 'cijioagents2', 'infracijioagents1']
+
 // Generate a parallel step for each label
-def generateParallelSteps(categorizedLabels) {
+def generateParallelSteps(categorizedLabels, clusters) {
     def parallelNodes = [:]
     categorizedLabels.each { categoryName, labels ->
         labels.each { unboundLabel ->
@@ -35,11 +37,23 @@ def generateParallelSteps(categorizedLabels) {
             }
         }
     }
+    clusters.each { clusterName -> 
+        parallelNodes[clusterName] = {
+            stage(clusterName) {
+                node('jnlp-linux-arm64') {
+                    withCredentials([file(credentialsId: "kubeconfig-${clusterName}", variable: 'KUBECONFIG')]) {
+                        sh 'kubectl cluster-info'
+                        sh 'kubectl get ns'
+                    }
+                }
+            }
+        }
+    }
     return parallelNodes
 }
 
 timeout(unit: 'MINUTES', time: 29) {
-    parallel generateParallelSteps(categorizedLabels)
+    parallel generateParallelSteps(categorizedLabels, clusters)
 }
 
 node('jnlp-linux-arm64') {


### PR DESCRIPTION
This change adds `kubectl` checks against all our clusters, in infra.ci pipeline as we don't want to run untrusted changes here.

Follow-up of:
- https://github.com/jenkins-infra/kubernetes-management/pull/7754

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952
- https://github.com/jenkins-infra/helpdesk/issues/5043#issuecomment-4144879015

### Testing done

Replay on infra.ci.jenkins.io: https://infra.ci.jenkins.io/job/acceptance-tests/job/acceptance-tests/job/check-agent-availability/218/